### PR TITLE
Unify: Standardize serialization naming (into-X/from-X)

### DIFF
--- a/packages/jth-stdlib/__tests__/serialization.test.mjs
+++ b/packages/jth-stdlib/__tests__/serialization.test.mjs
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { Stack } from "jth-runtime";
+import {
+  intoJson,
+  toJson,
+  fromJson,
+  intoLines,
+  toLines,
+  fromLines,
+} from "../src/serialization.mjs";
+
+describe("serialization", () => {
+  it("intoJson stringifies a value", () => {
+    const s = new Stack();
+    s.push({ a: 1 });
+    intoJson(s);
+    expect(s.toArray()).toEqual(['{"a":1}']);
+  });
+
+  it("toJson parses a JSON string", () => {
+    const s = new Stack();
+    s.push('{"a":1}');
+    toJson(s);
+    expect(s.toArray()).toEqual([{ a: 1 }]);
+  });
+
+  it("fromJson parses a JSON string (alias for toJson)", () => {
+    const s = new Stack();
+    s.push('{"b":2}');
+    fromJson(s);
+    expect(s.toArray()).toEqual([{ b: 2 }]);
+  });
+
+  it("fromJson parses a JSON array", () => {
+    const s = new Stack();
+    s.push("[1,2,3]");
+    fromJson(s);
+    expect(s.toArray()).toEqual([[1, 2, 3]]);
+  });
+
+  it("fromJson is the same function as toJson", () => {
+    expect(fromJson).toBe(toJson);
+  });
+
+  it("intoLines joins an array with newlines", () => {
+    const s = new Stack();
+    s.push(["a", "b", "c"]);
+    intoLines(s);
+    expect(s.toArray()).toEqual(["a\nb\nc"]);
+  });
+
+  it("toLines splits a string by newline", () => {
+    const s = new Stack();
+    s.push("a\nb\nc");
+    toLines(s);
+    expect(s.toArray()).toEqual([["a", "b", "c"]]);
+  });
+
+  it("fromLines splits a string by newline (alias for toLines)", () => {
+    const s = new Stack();
+    s.push("x\ny\nz");
+    fromLines(s);
+    expect(s.toArray()).toEqual([["x", "y", "z"]]);
+  });
+
+  it("fromLines splits a single line into one-element array", () => {
+    const s = new Stack();
+    s.push("single");
+    fromLines(s);
+    expect(s.toArray()).toEqual([["single"]]);
+  });
+
+  it("fromLines is the same function as toLines", () => {
+    expect(fromLines).toBe(toLines);
+  });
+});

--- a/packages/jth-stdlib/src/register.mjs
+++ b/packages/jth-stdlib/src/register.mjs
@@ -116,8 +116,10 @@ export function registerAll() {
   // Serialization
   registry.set("into-json", serialization.intoJson);
   registry.set("to-json", serialization.toJson);
+  registry.set("from-json", serialization.fromJson);
   registry.set("into-lines", serialization.intoLines);
   registry.set("to-lines", serialization.toLines);
+  registry.set("from-lines", serialization.fromLines);
 
   // Array ops
   registry.set("push", arrayOps.push);

--- a/packages/jth-stdlib/src/serialization.mjs
+++ b/packages/jth-stdlib/src/serialization.mjs
@@ -2,7 +2,9 @@ import { op } from "jth-runtime";
 
 export const intoJson = op(1)((a) => [JSON.stringify(a)]);
 export const toJson = op(1)((a) => [JSON.parse(a)]);
+export const fromJson = toJson;
 export const intoLines = op(1)((a) => [
   Array.isArray(a) ? a.join("\n") : String(a),
 ]);
 export const toLines = op(1)((a) => [String(a).split("\n")]);
+export const fromLines = toLines;


### PR DESCRIPTION
## Summary
- Adds `from-json` and `from-lines` aliases to complement existing `into-json`/`into-lines`
- Establishes the unified `into-X` (serialize) / `from-X` (parse) naming convention shared with hsab

## Changes
- 3 files changed, 80 insertions
- New serialization.test.mjs with tests for from-json and from-lines
- Aliases registered in stdlib register.mjs

## Test plan
- [x] Tests for from-json parsing JSON strings
- [x] Tests for from-lines splitting strings into arrays
- [x] Full test suite passes