### PR TITLE
Unify: Add over/rot stack operations

### DIFF
--- a/packages/jth-stdlib/__tests__/stack-ops.test.mjs
+++ b/packages/jth-stdlib/__tests__/stack-ops.test.mjs
@@ -23,6 +23,8 @@ import {
   collect,
   peek,
   view,
+  over,
+  rot,
 } from "../src/stack-ops.mjs";
 
 describe("stack-ops", () => {
@@ -218,5 +220,29 @@ describe("stack-ops", () => {
     expect(spy).toHaveBeenCalledWith(1, 2, 3);
     expect(s.toArray()).toEqual([1, 2, 3]);
     spy.mockRestore();
+  });
+
+  describe("over", () => {
+    it("copies second item to top: a b -- a b a", () => {
+      const s = new Stack();
+      s.push(1, 2);
+      over(s);
+      expect(s.toArray()).toEqual([1, 2, 1]);
+    });
+    it("works with different types", () => {
+      const s = new Stack();
+      s.push("hello", 42);
+      over(s);
+      expect(s.toArray()).toEqual(["hello", 42, "hello"]);
+    });
+  });
+
+  describe("rot", () => {
+    it("rotates top three: a b c -- b c a", () => {
+      const s = new Stack();
+      s.push(1, 2, 3);
+      rot(s);
+      expect(s.toArray()).toEqual([2, 3, 1]);
+    });
   });
 });

--- a/packages/jth-stdlib/src/register.mjs
+++ b/packages/jth-stdlib/src/register.mjs
@@ -34,6 +34,8 @@ export function registerAll() {
   registry.set("count", stackOps.count);
   registry.set("collect", stackOps.collect);
   registry.set("@", stackOps.peek);
+  registry.set("over", stackOps.over);
+  registry.set("rot", stackOps.rot);
   registry.set("@@", stackOps.view);
 
   // Arithmetic

--- a/packages/jth-stdlib/src/stack-ops.mjs
+++ b/packages/jth-stdlib/src/stack-ops.mjs
@@ -137,3 +137,9 @@ export const peek = (stack) => {
 export const view = (stack) => {
   console.log(...stack.toArray());
 };
+
+// over: copy second item to top (Forth: a b -- a b a)
+export const over = op(2)((a, b) => [a, b, a]);
+
+// rot: rotate top three items (Forth: a b c -- b c a)
+export const rot = op(3)((a, b, c) => [b, c, a]);


### PR DESCRIPTION
## Summary
- Adds `over` and `rot` Forth-style stack primitives to match hsab's stack operations
- `over`: copies second element to top (a b -> a b a)
- `rot`: rotates third element to top (a b c -> b c a)

## Changes
- 3 files changed, 34 insertions
- New over/rot operators in stack-ops.mjs
- Registered in stdlib register.mjs
- 762 tests passing

## Test plan
- [x] Tests for over with various stack states
- [x] Tests for rot with three+ elements
- [x] Full test suite passes (762 tests)