### PR TITLE
Unify: Add # comments, dup/depth/spread aliases

### DIFF
--- a/packages/jth-compiler/__tests__/lexer.test.mjs
+++ b/packages/jth-compiler/__tests__/lexer.test.mjs
@@ -579,6 +579,33 @@ describe("lexer: comments", () => {
     expect(tokens[1].type).toBe(TokenType.OPERATOR);
     expect(tokens[1].value).toBe("/");
   });
+
+  it("should lex # comment as COMMENT", () => {
+    const tok = first("# this is a comment");
+    expect(tok.type).toBe(TokenType.COMMENT);
+    expect(tok.value).toBe("this is a comment");
+  });
+
+  it("should lex # comment after code", () => {
+    const tokens = lexNoEof("42 # a number");
+    expect(tokens).toHaveLength(2);
+    expect(tokens[0].type).toBe(TokenType.NUMBER);
+    expect(tokens[0].value).toBe(42);
+    expect(tokens[1].type).toBe(TokenType.COMMENT);
+    expect(tokens[1].value).toBe("a number");
+  });
+
+  it("should produce no non-comment tokens for a line that is only a # comment", () => {
+    const tokens = lexNoEof("# this is a comment");
+    const nonComment = tokens.filter((t) => t.type !== TokenType.COMMENT);
+    expect(nonComment).toHaveLength(0);
+  });
+
+  it("should not confuse #[ block open with # comment", () => {
+    const tok = first("#[");
+    expect(tok.type).toBe(TokenType.BLOCK_OPEN);
+    expect(tok.value).toBe("#[");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/jth-compiler/src/lexer.mjs
+++ b/packages/jth-compiler/src/lexer.mjs
@@ -305,6 +305,19 @@ export function lex(source) {
     addToken(TokenType.COMMENT, text, startLine, startCol);
   }
 
+  function readHashComment(startLine, startCol) {
+    advance(); // skip #
+    let text = "";
+    // Skip leading space if present
+    if (pos < source.length && current() === " ") {
+      advance();
+    }
+    while (pos < source.length && current() !== "\n") {
+      text += advance();
+    }
+    addToken(TokenType.COMMENT, text, startLine, startCol);
+  }
+
   function readColon(startLine, startCol) {
     advance(); // skip first :
 
@@ -384,6 +397,12 @@ export function lex(source) {
       advance(); // #
       advance(); // [
       addToken(TokenType.BLOCK_OPEN, "#[", startLine, startCol);
+      continue;
+    }
+
+    // Hash comment: # (but not #[, which is handled above)
+    if (ch === "#") {
+      readHashComment(startLine, startCol);
       continue;
     }
 

--- a/packages/jth-stdlib/__tests__/control-flow.test.mjs
+++ b/packages/jth-stdlib/__tests__/control-flow.test.mjs
@@ -337,6 +337,41 @@ describe("control-flow", () => {
       timesOp(s);
       expect(s.toArray()).toEqual([42]);
     });
+
+    it("supports N [block] times order (number first, block second)", () => {
+      const s = new Stack();
+      s.push(0);
+      const block = (stack) => {
+        const val = stack.pop();
+        stack.push(val + 1);
+      };
+      // N [block] times -- number pushed first, then block
+      s.push(3, block);
+      timesOp(s);
+      expect(s.toArray()).toEqual([3]);
+    });
+
+    it("N [block] times gives same result as [block] N times", () => {
+      const block = (stack) => {
+        const val = stack.pop();
+        stack.push(val + 10);
+      };
+
+      // [block] N times (original order)
+      const s1 = new Stack();
+      s1.push(0);
+      s1.push(block, 5);
+      timesOp(s1);
+
+      // N [block] times (reversed order)
+      const s2 = new Stack();
+      s2.push(0);
+      s2.push(5, block);
+      timesOp(s2);
+
+      expect(s1.toArray()).toEqual(s2.toArray());
+      expect(s1.toArray()).toEqual([50]);
+    });
   });
 
   describe("loop", () => {

--- a/packages/jth-stdlib/__tests__/stack-ops.test.mjs
+++ b/packages/jth-stdlib/__tests__/stack-ops.test.mjs
@@ -10,6 +10,7 @@ import {
   dropHalf,
   copy,
   dupe,
+  dup,
   retrieve,
   dig,
   bury,
@@ -20,6 +21,7 @@ import {
   seed,
   reverse,
   count,
+  depth,
   collect,
   peek,
   view,
@@ -218,5 +220,47 @@ describe("stack-ops", () => {
     expect(spy).toHaveBeenCalledWith(1, 2, 3);
     expect(s.toArray()).toEqual([1, 2, 3]);
     spy.mockRestore();
+  });
+
+  describe("dup (alias of dupe)", () => {
+    it("duplicates the top item just like dupe", () => {
+      const s = new Stack();
+      s.push(1, 2, 3);
+      dup(s);
+      expect(s.toArray()).toEqual([1, 2, 3, 3]);
+    });
+
+    it("is the same function as dupe", () => {
+      expect(dup).toBe(dupe);
+    });
+  });
+
+  describe("depth (alias of count)", () => {
+    it("pushes stack length without consuming, just like count", () => {
+      const s = new Stack();
+      s.push(10, 20, 30);
+      depth(s);
+      expect(s.toArray()).toEqual([10, 20, 30, 3]);
+    });
+
+    it("is the same function as count", () => {
+      expect(depth).toBe(count);
+    });
+  });
+
+  describe("spread as word alias", () => {
+    it("pops an array and pushes elements individually onto stack", () => {
+      const s = new Stack();
+      s.push([1, 2, 3]);
+      spread(s);
+      expect(s.toArray()).toEqual([1, 2, 3]);
+    });
+
+    it("preserves items already on stack below the array", () => {
+      const s = new Stack();
+      s.push(99, [4, 5, 6]);
+      spread(s);
+      expect(s.toArray()).toEqual([99, 4, 5, 6]);
+    });
   });
 });

--- a/packages/jth-stdlib/src/control-flow.mjs
+++ b/packages/jth-stdlib/src/control-flow.mjs
@@ -99,9 +99,25 @@ export const keepIf = op(2)((value, condition) => (condition ? [value] : []));
 export const dropIf = op(2)((value, condition) => (condition ? [] : [value]));
 
 // times: { block } N times -- executes block N times
+// Also supports N { block } times (reversed argument order)
 export const timesOp = (stack) => {
-  const n = stack.pop();
-  const block = stack.pop();
+  let top = stack.pop();
+  let second = stack.pop();
+  // Detect argument order: support both [block] N and N [block]
+  let n, block;
+  if (typeof top === "number" && typeof second === "function") {
+    // Standard order: [block] N times
+    n = top;
+    block = second;
+  } else if (typeof top === "function" && typeof second === "number") {
+    // Reversed order: N [block] times
+    n = second;
+    block = top;
+  } else {
+    // Fallback to original behavior (top = n, second = block)
+    n = top;
+    block = second;
+  }
   for (let i = 0; i < n; i++) {
     if (typeof block === "function") block(stack);
   }

--- a/packages/jth-stdlib/src/register.mjs
+++ b/packages/jth-stdlib/src/register.mjs
@@ -26,12 +26,15 @@ export function registerAll() {
   registry.set("\u2205", stackOps.noop);
   registry.set("clear", stackOps.clear);
   registry.set("...", stackOps.spread);
+  registry.set("spread", stackOps.spread);
   registry.set("drop", stackOps.drop);
   registry.set("dupe", stackOps.dupe);
+  registry.set("dup", stackOps.dup);
   registry.set("copy", stackOps.copy);
   registry.set("swap", stackOps.swap);
   registry.set("reverse", stackOps.reverse);
   registry.set("count", stackOps.count);
+  registry.set("depth", stackOps.depth);
   registry.set("collect", stackOps.collect);
   registry.set("@", stackOps.peek);
   registry.set("@@", stackOps.view);

--- a/packages/jth-stdlib/src/stack-ops.mjs
+++ b/packages/jth-stdlib/src/stack-ops.mjs
@@ -137,3 +137,7 @@ export const peek = (stack) => {
 export const view = (stack) => {
   console.log(...stack.toArray());
 };
+
+// Aliases
+export const dup = dupe;
+export const depth = count;


### PR DESCRIPTION
## Summary
- Lexer now supports `#` as a comment character (in addition to existing `//`)
- Adds `dup` alias for `duplicate`, `depth` for stack depth, `spread` for array spread
- Adds flexible `times` order: both `[block] N times` and `N [block] times` work
- Unifies comment syntax and common aliases with hsab

## Changes
- 7 files changed, 150 insertions, 2 deletions
- Lexer: added `#` single-line comment support
- stdlib: dup, depth, spread aliases registered
- Control flow: flexible times argument order
- 771 tests passing

## Test plan
- [x] Tests for # comment parsing in lexer
- [x] Tests for dup, depth, spread aliases
- [x] Tests for flexible times order
- [x] Full test suite passes (771 tests)