### PR TITLE
Execute wave 2: publishing readiness, v0.4.0, issues #17, #20–#22, #25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Cross-package types/imports resolve through each package's dist/,
+      # so the build must precede typecheck and tests.
+      - name: Build
+        run: npm run build
+
       - name: Typecheck
         run: npm run typecheck
 
       - name: Test
-        run: npm test
+        run: npm run test:unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # TODO(#20): jth-eval is still plain .mjs with no tsconfig; once it is
-      # converted to TypeScript and joins the project-reference graph,
-      # `tsc -b` will cover it too.
       - name: Typecheck
         run: npm run typecheck
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: npm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Publish all workspace packages
+        run: npm publish --workspaces --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 John Henry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,65 @@
+# Publishing jth to npm
+
+The monorepo publishes nine packages: `jth-types`, `jth-runtime`, `jth-compiler`, `jth-stdlib`, `jth-repl`, `jth-eval`, `jth-html`, `jth-ai`, and the CLI **`jth-lang`** (directory `packages/jth-cli`, binary `jth`). All are published together at the same version from the workspace root.
+
+## One-time setup
+
+Choose one of:
+
+**A. CI publishing (recommended)** — set the `NPM_TOKEN` repository secret:
+
+1. Create an npm automation token: <https://www.npmjs.com/settings/~/tokens> → *Generate New Token* → **Automation** (bypasses 2FA for CI).
+2. Add it to the GitHub repo: *Settings → Secrets and variables → Actions → New repository secret*, name `NPM_TOKEN`.
+
+**B. Local publishing** — log in once on your machine:
+
+```bash
+npm login
+```
+
+## Release flow (CI)
+
+1. Make sure `main` is green and versions are bumped (all packages share one version; bump every `packages/*/package.json`, the root, and the inter-package `^x.y.z` ranges, then `npm install` to sync the lockfile).
+2. Create and publish a GitHub release (tag e.g. `v0.4.0`):
+
+   ```bash
+   gh release create v0.4.0 --title "v0.4.0" --generate-notes
+   ```
+
+3. The `Publish` workflow (`.github/workflows/publish.yml`) triggers on the published release: `npm ci` → `npm run build` → `npm test` → `npm publish --workspaces --access public`. It can also be run manually from the Actions tab (*workflow_dispatch*).
+
+## Release flow (local)
+
+```bash
+npm ci
+npm run build
+npm test
+npm publish --workspaces --access public
+```
+
+Each package's `prepublishOnly` runs its build again defensively; `files: ["dist"]` ensures only built output ships.
+
+## Verify
+
+```bash
+npm view jth-lang version
+npx -y jth-lang --help          # or: npm i -g jth-lang && jth --help
+```
+
+## Deprecating the old package names (optional)
+
+The CLI used to be planned/published as `jth-cli`. If old placeholder packages exist under your account, deprecate them so users are redirected:
+
+```bash
+npm deprecate jth-cli@"<=0.1.0" "Renamed to jth-lang"
+# and, if desired, the other legacy placeholders:
+npm deprecate jth-core@"<=0.1.0" "Superseded by the jth-lang toolchain"
+npm deprecate jth-tools@"<=0.1.0" "Superseded by the jth-lang toolchain"
+npm deprecate jth-stats@"<=0.1.0" "Superseded by the jth-lang toolchain"
+```
+
+## Notes
+
+- The npm name `jth` is owned by another user; the CLI is `jth-lang`, but the installed binary is still `jth`.
+- `jth-ai` is a JS-only helper library (registers no jth words); it publishes like the rest.
+- The smoke test (`test/smoke/pack-install.test.ts`) already exercises pack → install → run outside the repo on every `npm test`, so a green test run is a strong pre-publish signal.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ In jth, values are pushed onto a stack. Operators pop their arguments off the st
 ### Install
 
 ```bash
-npm install -g jth-cli
+npm install -g jth-lang
 ```
+
+(The npm package is `jth-lang`; the installed binary is `jth`.)
 
 ### Run a program
 
@@ -535,7 +537,7 @@ jth is organized as a monorepo with 9 packages:
 | **jth-runtime** | Stack VM, `processN`, `op()` helper, operator registry |
 | **jth-compiler** | Lexer, parser, code generator, transform pipeline |
 | **jth-stdlib** | Standard library (~110 operators) |
-| **jth-cli** | Command-line interface for running and compiling |
+| **jth-lang** | Command-line interface for running and compiling (binary: `jth`; directory: `packages/jth-cli`) |
 | **jth-repl** | Interactive REPL |
 | **jth-ai** | Ollama AI integration |
 | **jth-html** | HTML generation operators |
@@ -550,12 +552,44 @@ jth is organized as a monorepo with 9 packages:
 # Install dependencies
 npm install
 
-# Run all tests
+# Build every package to dist/ (ESM + .d.ts, via tsup)
+npm run build
+
+# Run all tests (builds first — see note below)
 npm test
+
+# Fast unit-test iteration (requires a previous build)
+npm run test:unit
 
 # Run tests in watch mode
 npm run test:watch
 
 # Run end-to-end tests
 npm run test:e2e
+
+# Typecheck (requires a previous build: cross-package types resolve
+# through each package's dist/*.d.ts)
+npm run typecheck
 ```
+
+### Contributing notes: build vs. dev resolution
+
+Every publishable package points its `main`/`types`/`exports` at `dist/`
+(built by `tsup` from `src/`, config in each package's `tsup.config.ts` +
+`tsconfig.build.json`). Cross-package imports (`jth-runtime`,
+`jth-types/ast`, …) therefore resolve to **built output** — in tests, in
+`tsc -b`, and at runtime. To keep that coherent:
+
+- `npm test` **always builds first**, so tests and the spawned CLI binary
+  (`packages/jth-cli/dist/bin/jth.js`) exercise fresh output.
+- After editing source, re-run `npm run build` (or use `npm test`) before
+  `npm run test:unit` / `npm run typecheck`, or you'll see stale code.
+- Relative imports within a package (`../src/foo.ts`) still resolve to
+  source under vitest/tsx, so pure unit tests iterate without a rebuild.
+- The CLI is published as **jth-lang** (binary `jth`), built as plain
+  node JS — `tsx` is a dev-only dependency. `jth compile` emits a
+  self-contained bundle by default (`--no-bundle` for the bare form), and
+  `jth run` executes a bundled temp module with plain node.
+- A slow smoke test (`test/smoke/pack-install.test.ts`) npm-packs
+  jth-lang + deps, installs them in a temp dir outside the repo, and runs
+  the installed binary.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jth-monorepo",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jth-monorepo",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "workspaces": [
         "packages/jth-types",
         "packages/jth-runtime",
@@ -2100,75 +2100,75 @@
       }
     },
     "packages/jth-ai": {
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "jth-runtime": "0.3.0"
+        "jth-runtime": "^0.4.0"
       }
     },
     "packages/jth-cli": {
       "name": "jth-lang",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "esbuild": "^0.27.3",
-        "jth-compiler": "0.3.0",
-        "jth-repl": "0.3.0",
-        "jth-runtime": "0.3.0",
-        "jth-stdlib": "0.3.0",
-        "jth-types": "0.3.0"
+        "jth-compiler": "^0.4.0",
+        "jth-repl": "^0.4.0",
+        "jth-runtime": "^0.4.0",
+        "jth-stdlib": "^0.4.0",
+        "jth-types": "^0.4.0"
       },
       "bin": {
         "jth": "dist/bin/jth.js"
       }
     },
     "packages/jth-compiler": {
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "jth-runtime": "0.3.0",
-        "jth-types": "0.3.0"
+        "jth-runtime": "^0.4.0",
+        "jth-types": "^0.4.0"
       },
       "devDependencies": {
-        "jth-stdlib": "0.3.0"
+        "jth-stdlib": "^0.4.0"
       }
     },
     "packages/jth-eval": {
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "jth-compiler": "0.3.0",
-        "jth-runtime": "0.3.0",
-        "jth-stdlib": "0.3.0",
-        "jth-types": "0.3.0"
+        "jth-compiler": "^0.4.0",
+        "jth-runtime": "^0.4.0",
+        "jth-stdlib": "^0.4.0",
+        "jth-types": "^0.4.0"
       }
     },
     "packages/jth-html": {
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "jth-runtime": "0.3.0"
+        "jth-runtime": "^0.4.0"
       }
     },
     "packages/jth-repl": {
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "jth-compiler": "0.3.0",
-        "jth-runtime": "0.3.0",
-        "jth-stdlib": "0.3.0",
-        "jth-types": "0.3.0"
+        "jth-compiler": "^0.4.0",
+        "jth-runtime": "^0.4.0",
+        "jth-stdlib": "^0.4.0",
+        "jth-types": "^0.4.0"
       }
     },
     "packages/jth-runtime": {
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "jth-types": "0.3.0"
+        "jth-types": "^0.4.0"
       }
     },
     "packages/jth-stdlib": {
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "jth-runtime": "0.3.0",
-        "jth-types": "0.3.0"
+        "jth-runtime": "^0.4.0",
+        "jth-types": "^0.4.0"
       }
     },
     "packages/jth-types": {
-      "version": "0.3.0"
+      "version": "0.4.0"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,15 @@
         "packages/jth-runtime",
         "packages/jth-compiler",
         "packages/jth-stdlib",
-        "packages/jth-cli",
         "packages/jth-repl",
-        "packages/jth-ai",
         "packages/jth-html",
-        "packages/jth-eval"
+        "packages/jth-ai",
+        "packages/jth-eval",
+        "packages/jth-cli"
       ],
       "devDependencies": {
         "@types/node": "^25.3.0",
+        "tsup": "^8.5.1",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^3.0.0"
@@ -32,7 +33,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -49,7 +49,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -66,7 +65,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -83,7 +81,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -100,7 +97,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -117,7 +113,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -134,7 +129,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -151,7 +145,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -168,7 +161,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -185,7 +177,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -202,7 +193,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -219,7 +209,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -236,7 +225,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -253,7 +241,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -270,7 +257,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -287,7 +273,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -304,7 +289,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -321,7 +305,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -338,7 +321,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -355,7 +337,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -372,7 +353,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -389,7 +369,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -406,7 +385,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -423,7 +401,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -440,7 +417,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -457,7 +433,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -467,12 +442,44 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
@@ -974,6 +981,26 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -982,6 +1009,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
       }
     },
     "node_modules/cac": {
@@ -1019,6 +1062,49 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/debug": {
@@ -1060,7 +1146,6 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1136,6 +1221,18 @@
         }
       }
     },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1164,6 +1261,16 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -1173,10 +1280,6 @@
     },
     "node_modules/jth-ai": {
       "resolved": "packages/jth-ai",
-      "link": true
-    },
-    "node_modules/jth-cli": {
-      "resolved": "packages/jth-cli",
       "link": true
     },
     "node_modules/jth-compiler": {
@@ -1189,6 +1292,10 @@
     },
     "node_modules/jth-html": {
       "resolved": "packages/jth-html",
+      "link": true
+    },
+    "node_modules/jth-lang": {
+      "resolved": "packages/jth-cli",
       "link": true
     },
     "node_modules/jth-repl": {
@@ -1207,6 +1314,36 @@
       "resolved": "packages/jth-types",
       "link": true
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -1224,12 +1361,37 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1248,6 +1410,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pathe": {
@@ -1287,6 +1459,28 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -1314,6 +1508,73 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -1378,6 +1639,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1413,6 +1684,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/tinybench": {
@@ -1476,6 +1793,76 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -1509,6 +1896,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
@@ -1712,8 +2106,10 @@
       }
     },
     "packages/jth-cli": {
+      "name": "jth-lang",
       "version": "0.3.0",
       "dependencies": {
+        "esbuild": "^0.27.3",
         "jth-compiler": "0.3.0",
         "jth-repl": "0.3.0",
         "jth-runtime": "0.3.0",
@@ -1721,7 +2117,7 @@
         "jth-types": "0.3.0"
       },
       "bin": {
-        "jth": "bin/jth.ts"
+        "jth": "dist/bin/jth.js"
       }
     },
     "packages/jth-compiler": {

--- a/package.json
+++ b/package.json
@@ -8,22 +8,28 @@
     "packages/jth-runtime",
     "packages/jth-compiler",
     "packages/jth-stdlib",
-    "packages/jth-cli",
     "packages/jth-repl",
-    "packages/jth-ai",
     "packages/jth-html",
-    "packages/jth-eval"
+    "packages/jth-ai",
+    "packages/jth-eval",
+    "packages/jth-cli"
   ],
   "devDependencies": {
     "@types/node": "^25.3.0",
+    "tsup": "^8.5.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^3.0.0"
   },
   "scripts": {
-    "test": "vitest run",
+    "build": "npm run build --workspaces --if-present",
+    "test": "npm run build && vitest run",
+    "test:unit": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "vitest run test/e2e/",
     "typecheck": "tsc -b"
+  },
+  "allowScripts": {
+    "esbuild@0.27.3": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jth-monorepo",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -31,5 +31,6 @@
   },
   "allowScripts": {
     "esbuild@0.27.3": true
-  }
+  },
+  "license": "MIT"
 }

--- a/packages/jth-ai/README.md
+++ b/packages/jth-ai/README.md
@@ -1,6 +1,8 @@
 # jth-ai
 
-AI integration for the jth language via Ollama. Provides stack-based operators for chatting with local LLMs.
+AI integration helpers for the jth runtime via Ollama — a **JavaScript-only helper library**, not a jth op package.
+
+> **Scope: JS-only.** Unlike `jth-html`, importing `jth-ai` does **not** register any operator names in the jth registry — there are no `infer`/`chat` words callable from a `.jth` program, and `::import "jth-ai";` registers nothing. Network access is deliberately kept out of the default jth vocabulary. The exports below are factory functions that *produce* stack operators for you to drive explicitly from JavaScript via `processN` (or to register yourself under names of your choosing).
 
 ## Installation
 

--- a/packages/jth-ai/package.json
+++ b/packages/jth-ai/package.json
@@ -3,6 +3,10 @@
   "version": "0.3.0",
   "type": "module",
   "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./ollama": "./src/ollama.ts"
+  },
   "dependencies": {
     "jth-runtime": "0.3.0"
   }

--- a/packages/jth-ai/package.json
+++ b/packages/jth-ai/package.json
@@ -23,5 +23,6 @@
   },
   "dependencies": {
     "jth-runtime": "^0.4.0"
-  }
+  },
+  "license": "MIT"
 }

--- a/packages/jth-ai/package.json
+++ b/packages/jth-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jth-ai",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -22,6 +22,6 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "jth-runtime": "0.3.0"
+    "jth-runtime": "^0.4.0"
   }
 }

--- a/packages/jth-ai/package.json
+++ b/packages/jth-ai/package.json
@@ -2,10 +2,24 @@
   "name": "jth-ai",
   "version": "0.3.0",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./ollama": "./src/ollama.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./ollama": {
+      "types": "./dist/ollama.d.ts",
+      "default": "./dist/ollama.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "jth-runtime": "0.3.0"

--- a/packages/jth-ai/tsconfig.build.json
+++ b/packages/jth-ai/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declarationMap": false,
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/jth-ai/tsup.config.ts
+++ b/packages/jth-ai/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    "index": "src/index.ts",
+    "ollama": "src/ollama.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  target: "node20",
+  platform: "node",
+  tsconfig: "tsconfig.build.json",
+});

--- a/packages/jth-cli/README.md
+++ b/packages/jth-cli/README.md
@@ -1,18 +1,20 @@
-# jth-cli
+# jth-lang
 
-Command-line interface for compiling and running jth programs.
+Command-line interface for compiling and running jth programs. The npm package is **`jth-lang`** (the binary it installs is `jth`).
+
+> Renamed from `jth-cli`: the npm name `jth` is taken, so the CLI ships as `jth-lang`. The internal packages keep their names (`jth-runtime`, `jth-compiler`, …).
 
 ## Installation
 
 ```bash
-npm install -g jth-cli
+npm install -g jth-lang
 ```
 
 ## Commands
 
 ### `jth run <file>`
 
-Compile and execute a `.jth` file.
+Compile and execute a `.jth` file. The program is bundled into a self-contained temp module (in the OS temp dir — nothing is written next to your sources) and executed with plain node.
 
 ```bash
 jth run hello.jth
@@ -30,25 +32,39 @@ jth run -c '"hello world" peek;'
 
 Compile a `.jth` file to a `.mjs` JavaScript module. If no output path is given, the output filename is derived from the input (replacing `.jth` with `.mjs`).
 
+By default the output is a **self-contained bundle** — jth-runtime and jth-stdlib are inlined, so `node output.mjs` works from any directory with nothing installed:
+
 ```bash
-jth compile math.jth              # writes math.mjs
-jth compile math.jth output.mjs   # writes output.mjs
+jth compile math.jth              # writes math.mjs (bundled)
+jth compile math.jth output.mjs   # writes output.mjs (bundled)
+node output.mjs                   # runs anywhere
+```
+
+With `--no-bundle`, the output keeps bare `"jth-runtime"` / `"jth-stdlib"` imports — smaller and readable, for projects that have the jth packages installed (also the right form for library modules that a bundled main program will import):
+
+```bash
+jth compile --no-bundle math.jth
 ```
 
 ### `jth compile -c '<code>'`
 
-Compile inline jth code and print the resulting JavaScript to stdout.
+Compile inline jth code and print the resulting JavaScript to stdout (always the unbundled form, for inspection).
 
 ```bash
 jth compile -c '1 2 + peek;'
 ```
 
+### `jth repl`
+
+Start the interactive REPL.
+
 ### Flags
 
-| Flag              | Description          |
-|-------------------|----------------------|
-| `--version`, `-v` | Print version number |
-| `--help`, `-h`    | Print help message   |
+| Flag              | Description                                |
+|-------------------|--------------------------------------------|
+| `--no-bundle`     | (compile) emit bare-specifier output       |
+| `--version`, `-v` | Print version number                       |
+| `--help`, `-h`    | Print help message                         |
 
 ## Examples
 
@@ -58,6 +74,9 @@ jth run program.jth
 
 # Quick one-liner
 jth run -c '5 3 + peek;'
+
+# Portable compiled artifact
+jth compile program.jth && node program.mjs
 
 # Inspect compiled output
 jth compile -c '1 2 + dup * peek;'

--- a/packages/jth-cli/__tests__/cli.test.ts
+++ b/packages/jth-cli/__tests__/cli.test.ts
@@ -67,6 +67,11 @@ describe("compile: inline code", () => {
     expect(js).not.toContain(".jth");
   });
 
+  it("passes through bare package imports (opt-in op packages like jth-html)", () => {
+    const js = compile('::import "jth-html";', { isCode: true });
+    expect(js).toContain('import "jth-html";');
+  });
+
   it("compiles export statements", () => {
     const js = compile("::export square cube;", { isCode: true });
     expect(js).toContain("export { square, cube }");

--- a/packages/jth-cli/__tests__/run.test.ts
+++ b/packages/jth-cli/__tests__/run.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Integration tests for `jth run` through the REAL CLI spawn path:
+ * compile to a temp .mjs, spawn node, inherit stdio, clean up.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, readdirSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN = resolve(__dirname, "..", "bin", "jth.ts");
+// Temp dirs live inside the repo tree: compiled output currently imports
+// bare "jth-runtime"/"jth-stdlib" specifiers, which only resolve against
+// the monorepo's node_modules (see #17 for the portability story).
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+
+function jth(args: string[], cwd: string) {
+  return spawnSync(process.execPath, ["--import", "tsx", BIN, ...args], {
+    cwd,
+    encoding: "utf-8",
+    timeout: 60_000,
+  });
+}
+
+describe("jth run (real CLI spawn path)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(REPO_ROOT, ".jth-run-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("runs a .jth file: correct stdout and exit code 0", () => {
+    const file = join(dir, "hello.jth");
+    writeFileSync(file, '"hello from jth run" peek;', "utf-8");
+    const result = jth(["run", file], dir);
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("hello from jth run");
+  });
+
+  it("cleans up the temp .mjs written next to the source", () => {
+    const file = join(dir, "prog.jth");
+    writeFileSync(file, "1 2 + peek;", "utf-8");
+    const result = jth(["run", file], dir);
+    expect(result.status).toBe(0);
+    // run() writes .jth-run-<hex>.mjs next to the source and removes it
+    // in a finally block — nothing but the source may remain.
+    expect(readdirSync(dir)).toEqual(["prog.jth"]);
+  });
+
+  it("cleans up the temp .mjs even when the program fails", () => {
+    const file = join(dir, "bad.jth");
+    writeFileSync(file, "1 no-such-op;", "utf-8");
+    const result = jth(["run", file], dir);
+    expect(result.status).not.toBe(0);
+    expect(readdirSync(dir)).toEqual(["bad.jth"]);
+  });
+
+  it("runs inline code with -c (temp file in cwd, cleaned up)", () => {
+    const result = jth(["run", "-c", "6 7 * peek;"], dir);
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("42");
+    expect(readdirSync(dir)).toEqual([]);
+  });
+
+  it("reports jth errors with source position and exits 1", () => {
+    const file = join(dir, "err.jth");
+    writeFileSync(file, "1 2 bogus-op;", "utf-8");
+    const result = jth(["run", file], dir);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Unknown operator: bogus-op");
+    expect(result.stderr).toMatch(/at \d+:\d+/);
+  });
+
+  it("relative .jth imports resolve next to the source file", () => {
+    // lib.jth compiles to lib.mjs; main.jth imports it by relative path.
+    const lib = join(dir, "lib.jth");
+    writeFileSync(lib, "#[ dupe * ] :square;\n::export square;", "utf-8");
+    const compiled = jth(["compile", lib], dir);
+    expect(compiled.status).toBe(0);
+
+    const main = join(dir, "main.jth");
+    writeFileSync(
+      main,
+      '::import "./lib.jth" { square };\n7 square peek;',
+      "utf-8"
+    );
+    const result = jth(["run", main], dir);
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("49");
+  });
+});

--- a/packages/jth-cli/__tests__/run.test.ts
+++ b/packages/jth-cli/__tests__/run.test.ts
@@ -1,34 +1,39 @@
 /**
- * Integration tests for `jth run` through the REAL CLI spawn path:
- * compile to a temp .mjs, spawn node, inherit stdio, clean up.
+ * Integration tests for `jth run` through the REAL built CLI (plain node,
+ * no tsx): compile, bundle self-contained, spawn node, clean up.
+ *
+ * Requires a build (`npm run build`) — the root `npm test` script builds
+ * first. Temp dirs live in the OS temp dir on purpose: bundled output must
+ * run outside the monorepo tree.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync, readdirSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, readdirSync, existsSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const BIN = resolve(__dirname, "..", "bin", "jth.ts");
-// Temp dirs live inside the repo tree: compiled output currently imports
-// bare "jth-runtime"/"jth-stdlib" specifiers, which only resolve against
-// the monorepo's node_modules (see #17 for the portability story).
-const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+const BIN = resolve(__dirname, "..", "dist", "bin", "jth.js");
 
 function jth(args: string[], cwd: string) {
-  return spawnSync(process.execPath, ["--import", "tsx", BIN, ...args], {
+  return spawnSync(process.execPath, [BIN, ...args], {
     cwd,
     encoding: "utf-8",
     timeout: 60_000,
   });
 }
 
-describe("jth run (real CLI spawn path)", () => {
+describe("jth run (built CLI, spawn path)", () => {
   let dir: string;
 
   beforeEach(() => {
-    dir = mkdtempSync(join(REPO_ROOT, ".jth-run-test-"));
+    expect(
+      existsSync(BIN),
+      "dist/bin/jth.js missing — run `npm run build` first (root `npm test` does)"
+    ).toBe(true);
+    dir = mkdtempSync(join(tmpdir(), "jth-run-test-"));
   });
 
   afterEach(() => {
@@ -43,17 +48,15 @@ describe("jth run (real CLI spawn path)", () => {
     expect(result.stdout.trim()).toBe("hello from jth run");
   });
 
-  it("cleans up the temp .mjs written next to the source", () => {
+  it("writes nothing next to the user's source (temp file lives in os.tmpdir)", () => {
     const file = join(dir, "prog.jth");
     writeFileSync(file, "1 2 + peek;", "utf-8");
     const result = jth(["run", file], dir);
     expect(result.status).toBe(0);
-    // run() writes .jth-run-<hex>.mjs next to the source and removes it
-    // in a finally block — nothing but the source may remain.
     expect(readdirSync(dir)).toEqual(["prog.jth"]);
   });
 
-  it("cleans up the temp .mjs even when the program fails", () => {
+  it("leaves no litter even when the program fails", () => {
     const file = join(dir, "bad.jth");
     writeFileSync(file, "1 no-such-op;", "utf-8");
     const result = jth(["run", file], dir);
@@ -61,7 +64,7 @@ describe("jth run (real CLI spawn path)", () => {
     expect(readdirSync(dir)).toEqual(["bad.jth"]);
   });
 
-  it("runs inline code with -c (temp file in cwd, cleaned up)", () => {
+  it("runs inline code with -c", () => {
     const result = jth(["run", "-c", "6 7 * peek;"], dir);
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe("42");
@@ -78,10 +81,11 @@ describe("jth run (real CLI spawn path)", () => {
   });
 
   it("relative .jth imports resolve next to the source file", () => {
-    // lib.jth compiles to lib.mjs; main.jth imports it by relative path.
+    // Multi-file flow: compile the library unbundled (bare specifiers) so
+    // the main program's bundling step inlines it once.
     const lib = join(dir, "lib.jth");
     writeFileSync(lib, "#[ dupe * ] :square;\n::export square;", "utf-8");
-    const compiled = jth(["compile", lib], dir);
+    const compiled = jth(["compile", "--no-bundle", lib], dir);
     expect(compiled.status).toBe(0);
 
     const main = join(dir, "main.jth");
@@ -93,5 +97,51 @@ describe("jth run (real CLI spawn path)", () => {
     const result = jth(["run", main], dir);
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe("49");
+  });
+});
+
+describe("jth compile (built CLI)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "jth-compile-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("default output is a self-contained bundle runnable with plain node anywhere", () => {
+    const file = join(dir, "prog.jth");
+    writeFileSync(file, "20 22 + peek;", "utf-8");
+    const out = join(dir, "prog.mjs");
+    const compiled = jth(["compile", file, out], dir);
+    expect(compiled.status).toBe(0);
+
+    // Run from an unrelated directory with plain node — no jth packages
+    // installed there, no tsx.
+    const other = mkdtempSync(join(tmpdir(), "jth-elsewhere-"));
+    try {
+      const result = spawnSync(process.execPath, [out], {
+        cwd: other,
+        encoding: "utf-8",
+        timeout: 60_000,
+      });
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim()).toBe("42");
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  it("--no-bundle emits the bare-specifier form", () => {
+    const file = join(dir, "prog.jth");
+    writeFileSync(file, "1 2 +;", "utf-8");
+    const out = join(dir, "bare.mjs");
+    const compiled = jth(["compile", "--no-bundle", file, out], dir);
+    expect(compiled.status).toBe(0);
+    const js = readFileSync(out, "utf-8");
+    expect(js).toContain('from "jth-runtime"');
+    expect(js).toContain('import "jth-stdlib"');
   });
 });

--- a/packages/jth-cli/bin/jth.ts
+++ b/packages/jth-cli/bin/jth.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env node
 
 /**
  * jth CLI — compile and run .jth programs.
@@ -6,26 +6,34 @@
  * Usage:
  *   jth run <file>              Compile and run a .jth file
  *   jth run -c '<code>'         Compile and run inline jth code
- *   jth compile <file> [output] Compile a .jth file to .mjs
- *   jth compile -c '<code>'     Compile inline jth code to stdout
+ *   jth compile <file> [output] Compile a .jth file to a self-contained .mjs
+ *   jth compile --no-bundle <file> [output]
+ *                               Compile without bundling (bare jth-* imports)
+ *   jth compile -c '<code>'     Compile inline jth code to stdout (unbundled)
  *   jth repl                    Start interactive REPL
  *   jth --version | -v          Print version
  *   jth --help | -h             Print help
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { compile, deriveOutputPath } from "../src/compile.ts";
+import { compile, compileBundled, deriveOutputPath } from "../src/compile.ts";
 import { run } from "../src/run.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 function getVersion(): string {
-  const pkg = JSON.parse(
-    readFileSync(resolve(__dirname, "..", "package.json"), "utf-8")
-  );
-  return pkg.version;
+  // In dev the bin lives at <pkg>/bin/jth.ts (package.json one level up);
+  // built, it lives at <pkg>/dist/bin/jth.js (two levels up).
+  for (const rel of ["..", "../.."] as const) {
+    const candidate = resolve(__dirname, rel, "package.json");
+    if (existsSync(candidate)) {
+      const pkg = JSON.parse(readFileSync(candidate, "utf-8"));
+      if (pkg.name === "jth-lang") return pkg.version;
+    }
+  }
+  return "unknown";
 }
 
 const HELP = `
@@ -34,16 +42,24 @@ jth v${getVersion()} — stack-based language CLI
 Usage:
   jth run <file>              Compile and execute a .jth file
   jth run -c '<code>'         Compile and execute inline jth code
-  jth compile <file> [output] Compile a .jth file to .mjs
-  jth compile -c '<code>'     Compile inline jth code (prints to stdout)
+  jth compile <file> [output] Compile a .jth file to a self-contained .mjs
+                              (bundles jth-runtime + jth-stdlib; runs with
+                              plain \`node output.mjs\` anywhere)
+  jth compile --no-bundle <file> [output]
+                              Compile without bundling: output imports
+                              "jth-runtime"/"jth-stdlib" as bare specifiers
+                              (requires those packages to be installed)
+  jth compile -c '<code>'     Compile inline jth code (prints unbundled
+                              output to stdout)
   jth repl                    Start interactive REPL
   jth --version, -v           Print version
   jth --help, -h              Print this help message
 
 Examples:
   jth run hello.jth
-  jth run -c '"hello" @;'
-  jth compile math.jth math.mjs
+  jth run -c '"hello" peek;'
+  jth compile math.jth math.mjs && node math.mjs
+  jth compile --no-bundle math.jth
   jth compile -c '1 2 +;'
 `.trim();
 
@@ -70,7 +86,7 @@ switch (command) {
     break;
 
   case "compile":
-    handleCompile(rest);
+    await handleCompile(rest);
     break;
 
   case "repl":
@@ -114,19 +130,26 @@ async function handleRun(argv: string[]): Promise<void> {
   }
 }
 
-function handleCompile(argv: string[]): void {
-  const { isCode, input, extra } = parseInput(argv, "compile");
+async function handleCompile(argv: string[]): Promise<void> {
+  const bundle = !argv.includes("--no-bundle");
+  const filtered = argv.filter((a) => a !== "--no-bundle");
+  const { isCode, input, extra } = parseInput(filtered, "compile");
 
   try {
     if (isCode) {
-      // Inline code — always print to stdout
+      // Inline code — always print the unbundled form to stdout
       const js = compile(input, { isCode: true });
       console.log(js);
     } else {
       // File input
       const output = extra || deriveOutputPath(input);
-      compile(input, { isCode: false, output });
-      console.error(`Compiled: ${input} -> ${output}`);
+      if (bundle) {
+        await compileBundled(input, { isCode: false, output });
+        console.error(`Compiled (bundled): ${input} -> ${output}`);
+      } else {
+        compile(input, { isCode: false, output });
+        console.error(`Compiled: ${input} -> ${output}`);
+      }
     }
   } catch (err: any) {
     reportError(err);

--- a/packages/jth-cli/package.json
+++ b/packages/jth-cli/package.json
@@ -28,5 +28,6 @@
     "jth-types": "^0.4.0",
     "jth-repl": "^0.4.0",
     "esbuild": "^0.27.3"
-  }
+  },
+  "license": "MIT"
 }

--- a/packages/jth-cli/package.json
+++ b/packages/jth-cli/package.json
@@ -1,16 +1,32 @@
 {
-  "name": "jth-cli",
+  "name": "jth-lang",
   "version": "0.3.0",
+  "description": "jth — a stack-based language. CLI: compile and run .jth programs (binary: jth).",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "bin": {
-    "jth": "./bin/jth.ts"
+    "jth": "./dist/bin/jth.js"
+  },
+  "scripts": {
+    "build": "tsup",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "jth-compiler": "0.3.0",
     "jth-runtime": "0.3.0",
     "jth-stdlib": "0.3.0",
     "jth-types": "0.3.0",
-    "jth-repl": "0.3.0"
+    "jth-repl": "0.3.0",
+    "esbuild": "^0.27.3"
   }
 }

--- a/packages/jth-cli/package.json
+++ b/packages/jth-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jth-lang",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "jth — a stack-based language. CLI: compile and run .jth programs (binary: jth).",
   "type": "module",
   "main": "./dist/index.js",
@@ -22,11 +22,11 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "jth-compiler": "0.3.0",
-    "jth-runtime": "0.3.0",
-    "jth-stdlib": "0.3.0",
-    "jth-types": "0.3.0",
-    "jth-repl": "0.3.0",
+    "jth-compiler": "^0.4.0",
+    "jth-runtime": "^0.4.0",
+    "jth-stdlib": "^0.4.0",
+    "jth-types": "^0.4.0",
+    "jth-repl": "^0.4.0",
     "esbuild": "^0.27.3"
   }
 }

--- a/packages/jth-cli/src/bundle.ts
+++ b/packages/jth-cli/src/bundle.ts
@@ -1,0 +1,80 @@
+/**
+ * Self-contained bundling of compiled jth programs.
+ *
+ * `jth compile` / `jth run` emit JavaScript whose preamble imports
+ * "jth-runtime" and "jth-stdlib" (and possibly opt-in op packages like
+ * "jth-html"). Those bare specifiers only resolve where the packages are
+ * installed. To make compiled output portable — `node out.mjs` from any
+ * directory — we bundle it with esbuild, inlining the jth packages.
+ *
+ * Resolution model: jth-* specifiers are resolved from THIS package's own
+ * installation (the CLI declares jth-runtime/jth-stdlib/... as real
+ * dependencies), so a globally installed jth-lang always finds its own
+ * copies. Anything else (relative imports like "./lib.mjs", other npm
+ * packages) resolves relative to the source file's directory.
+ */
+
+import { build } from "esbuild";
+import type { Plugin } from "esbuild";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+/**
+ * Resolve a jth package specifier from the CLI's own installation.
+ * Returns a filesystem path, or null to fall back to default resolution
+ * (which esbuild performs relative to the program's resolveDir — that lets
+ * user projects supply their own op packages, e.g. a locally installed
+ * jth-html when the CLI doesn't ship it).
+ */
+function resolveFromCli(specifier: string): string | null {
+  try {
+    // import.meta.resolve is synchronous on Node 20+.
+    const url = import.meta.resolve(specifier);
+    if (url.startsWith("file:")) return fileURLToPath(url);
+  } catch {
+    // fall through
+  }
+  try {
+    // Fallback (also covers environments where import.meta.resolve is
+    // unavailable): CommonJS resolution hits the "default" export condition.
+    return createRequire(import.meta.url).resolve(specifier);
+  } catch {
+    return null;
+  }
+}
+
+const jthResolverPlugin: Plugin = {
+  name: "jth-package-resolver",
+  setup(build) {
+    build.onResolve({ filter: /^jth-[a-z-]+(\/.*)?$/ }, (args) => {
+      const path = resolveFromCli(args.path);
+      return path ? { path } : undefined;
+    });
+  },
+};
+
+/**
+ * Bundle compiled jth program JavaScript into a single self-contained
+ * ESM module string. Relative imports resolve against `resolveDir`.
+ */
+export async function bundleProgram(js: string, resolveDir: string): Promise<string> {
+  const result = await build({
+    stdin: {
+      contents: js,
+      resolveDir,
+      sourcefile: "jth-program.mjs",
+      loader: "js",
+    },
+    bundle: true,
+    format: "esm",
+    platform: "node",
+    target: "node20",
+    write: false,
+    logLevel: "silent",
+    plugins: [jthResolverPlugin],
+    banner: {
+      js: "// Compiled by jth (self-contained bundle: includes jth-runtime + jth-stdlib).",
+    },
+  });
+  return result.outputFiles[0].text;
+}

--- a/packages/jth-cli/src/compile.ts
+++ b/packages/jth-cli/src/compile.ts
@@ -1,12 +1,19 @@
 /**
  * Compile command: transform jth source to JavaScript.
  *
- * Reads source from a file path or inline string, runs the jth-compiler
- * transform pipeline, and either writes the result to a file or returns it.
+ * Two output forms:
+ *   - Bundled (default for `jth compile <file>`): a self-contained ESM
+ *     module with jth-runtime/jth-stdlib inlined — `node out.mjs` works
+ *     from any directory with no packages installed.
+ *   - Bare (--no-bundle, and the default of the `compile()` API / inline
+ *     `-c` output): the raw transform result, importing "jth-runtime" and
+ *     "jth-stdlib" as bare specifiers — for users who have the jth
+ *     packages installed in their project.
  */
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve, dirname, basename, extname } from "node:path";
 import { transform } from "jth-compiler";
+import { bundleProgram } from "./bundle.ts";
 
 interface CompileOptions {
   isCode?: boolean;
@@ -14,7 +21,7 @@ interface CompileOptions {
 }
 
 /**
- * Compile jth source code to JavaScript.
+ * Compile jth source code to JavaScript (bare-specifier form, synchronous).
  */
 export function compile(input: string, { isCode = false, output = null }: CompileOptions = {}): string {
   // 1. Obtain source
@@ -30,6 +37,26 @@ export function compile(input: string, { isCode = false, output = null }: Compil
   }
 
   return js;
+}
+
+/**
+ * Compile jth source code to a self-contained JavaScript bundle
+ * (jth-runtime + jth-stdlib inlined; relative imports resolved against
+ * the source file's directory).
+ */
+export async function compileBundled(
+  input: string,
+  { isCode = false, output = null }: CompileOptions = {}
+): Promise<string> {
+  const source = isCode ? input : readFileSync(resolve(input), "utf-8");
+  const js = transform(source, { preamble: true });
+  const resolveDir = isCode ? process.cwd() : dirname(resolve(input));
+  const bundled = await bundleProgram(js, resolveDir);
+
+  if (output) {
+    writeFileSync(resolve(output), bundled, "utf-8");
+  }
+  return bundled;
 }
 
 /**

--- a/packages/jth-cli/src/index.ts
+++ b/packages/jth-cli/src/index.ts
@@ -1,2 +1,3 @@
-export { compile, deriveOutputPath } from "./compile.ts";
+export { compile, compileBundled, deriveOutputPath } from "./compile.ts";
 export { run } from "./run.ts";
+export { bundleProgram } from "./bundle.ts";

--- a/packages/jth-cli/src/run.ts
+++ b/packages/jth-cli/src/run.ts
@@ -1,42 +1,46 @@
 /**
- * Run command: compile jth source, write to temp file, execute with tsx.
+ * Run command: compile jth source, bundle it into a self-contained module,
+ * write it to a temp file in the OS temp dir, and execute with plain node.
  *
- * The temp file is placed next to the source file (or cwd for inline code)
- * so that relative imports in the compiled output resolve correctly.
+ * Because the output is bundled (jth-runtime/jth-stdlib inlined, relative
+ * imports resolved at bundle time against the source directory), nothing
+ * is written next to the user's sources and no loader (tsx) is needed at
+ * runtime.
  */
 import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import { resolve, dirname, join } from "node:path";
+import { tmpdir } from "node:os";
 import { spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { transform } from "jth-compiler";
+import { bundleProgram } from "./bundle.ts";
 
 interface RunOptions {
   isCode?: boolean;
 }
 
 /**
- * Compile and execute jth source code.
+ * Compile and execute jth source code. Returns the child exit code.
  */
 export async function run(input: string, { isCode = false }: RunOptions = {}): Promise<number> {
   // 1. Obtain source
   const source = isCode ? input : readFileSync(resolve(input), "utf-8");
 
-  // 2. Transform to JavaScript
+  // 2. Transform to JavaScript (bare-specifier preamble)
   const js = transform(source, { preamble: true });
 
-  // 3. Determine temp file location
-  //    Place next to source for correct relative import resolution.
-  const baseDir = isCode ? process.cwd() : dirname(resolve(input));
-  const tmpName = `.jth-run-${randomBytes(6).toString("hex")}.mjs`;
-  const tmpPath = join(baseDir, tmpName);
+  // 3. Bundle: inline jth packages; resolve the program's own relative
+  //    imports against the source file's directory (cwd for inline code).
+  const resolveDir = isCode ? process.cwd() : dirname(resolve(input));
+  const bundled = await bundleProgram(js, resolveDir);
 
-  // 4. Write temp file
-  writeFileSync(tmpPath, js, "utf-8");
+  // 4. Write self-contained temp file (OS temp dir — never next to sources)
+  const tmpPath = join(tmpdir(), `jth-run-${randomBytes(6).toString("hex")}.mjs`);
+  writeFileSync(tmpPath, bundled, "utf-8");
 
-  // 5. Spawn node with tsx loader for TypeScript package resolution
+  // 5. Execute with plain node
   try {
-    const code = await spawnNode(tmpPath);
-    return code;
+    return await spawnNode(tmpPath);
   } finally {
     // 6. Clean up temp file
     try {
@@ -48,16 +52,16 @@ export async function run(input: string, { isCode = false }: RunOptions = {}): P
 }
 
 /**
- * Spawn a node process with tsx loader to run the given file, inheriting stdio.
+ * Spawn a plain node process to run the given file, inheriting stdio.
  */
 function spawnNode(filePath: string): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, ["--import", "tsx", filePath], {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, [filePath], {
       stdio: "inherit",
       env: { ...process.env },
     });
 
     child.on("error", reject);
-    child.on("close", (code) => resolve(code ?? 1));
+    child.on("close", (code) => resolvePromise(code ?? 1));
   });
 }

--- a/packages/jth-cli/tsconfig.build.json
+++ b/packages/jth-cli/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/jth-cli/tsup.config.ts
+++ b/packages/jth-cli/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    "bin/jth": "bin/jth.ts",
+  },
+  format: ["esm"],
+  // d.ts only for the library entry; the bin is an executable.
+  dts: { entry: { index: "src/index.ts" } },
+  clean: true,
+  target: "node20",
+  platform: "node",
+  tsconfig: "tsconfig.build.json",
+});

--- a/packages/jth-compiler/package.json
+++ b/packages/jth-compiler/package.json
@@ -43,5 +43,6 @@
   },
   "devDependencies": {
     "jth-stdlib": "^0.4.0"
-  }
+  },
+  "license": "MIT"
 }

--- a/packages/jth-compiler/package.json
+++ b/packages/jth-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jth-compiler",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -38,10 +38,10 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "jth-types": "0.3.0",
-    "jth-runtime": "0.3.0"
+    "jth-types": "^0.4.0",
+    "jth-runtime": "^0.4.0"
   },
   "devDependencies": {
-    "jth-stdlib": "0.3.0"
+    "jth-stdlib": "^0.4.0"
   }
 }

--- a/packages/jth-compiler/package.json
+++ b/packages/jth-compiler/package.json
@@ -2,14 +2,40 @@
   "name": "jth-compiler",
   "version": "0.3.0",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./lexer": "./src/lexer.ts",
-    "./parser": "./src/parser.ts",
-    "./codegen": "./src/codegen.ts",
-    "./transform": "./src/transform.ts",
-    "./run": "./src/run.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./lexer": {
+      "types": "./dist/lexer.d.ts",
+      "default": "./dist/lexer.js"
+    },
+    "./parser": {
+      "types": "./dist/parser.d.ts",
+      "default": "./dist/parser.js"
+    },
+    "./codegen": {
+      "types": "./dist/codegen.d.ts",
+      "default": "./dist/codegen.js"
+    },
+    "./transform": {
+      "types": "./dist/transform.d.ts",
+      "default": "./dist/transform.js"
+    },
+    "./run": {
+      "types": "./dist/run.d.ts",
+      "default": "./dist/run.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "jth-types": "0.3.0",

--- a/packages/jth-compiler/src/codegen.ts
+++ b/packages/jth-compiler/src/codegen.ts
@@ -46,11 +46,38 @@ function sanitize(name: string): string {
     .replace(/\?$/, "_p");
 }
 
+export interface GenerateOptions {
+  preamble?: boolean;
+  /**
+   * When true, InlineJSExpression nodes (`((...))`) throw at compile time
+   * with code OP_NOT_ALLOWED. Used by sandboxed evaluation (jth-eval):
+   * inline JS trivially escapes any operator allowlist, so sandboxes must
+   * reject it before any code runs.
+   */
+  forbidInlineJS?: boolean;
+}
+
+/**
+ * Module-scope compile flag: set for the duration of a generate() call.
+ * generate() is the only entry point and is synchronous, so this cannot
+ * interleave across compilations.
+ */
+let inlineJSForbidden = false;
+
 /**
  * Generate JavaScript source from a jth AST.
  */
-export function generate(ast: ProgramNodeType, options: { preamble?: boolean } = {}): string {
-  const { preamble = true } = options;
+export function generate(ast: ProgramNodeType, options: GenerateOptions = {}): string {
+  const { preamble = true, forbidInlineJS = false } = options;
+  inlineJSForbidden = forbidInlineJS;
+  try {
+    return generateProgram(ast, preamble);
+  } finally {
+    inlineJSForbidden = false;
+  }
+}
+
+function generateProgram(ast: ProgramNodeType, preamble: boolean): string {
   const lines: string[] = [];
 
   if (preamble) {
@@ -157,6 +184,14 @@ function generateExpression(node: any): string {
     }
 
     case "InlineJSExpression":
+      if (inlineJSForbidden) {
+        throw new JthRuntimeError(
+          "Inline JS ((...)) is not allowed in sandbox mode",
+          node?.line,
+          node?.column,
+          "OP_NOT_ALLOWED"
+        );
+      }
       return node.code;
 
     case "Definition":

--- a/packages/jth-compiler/src/index.ts
+++ b/packages/jth-compiler/src/index.ts
@@ -1,6 +1,7 @@
 export { lex } from "./lexer.ts";
 export { parse } from "./parser.ts";
 export { generate } from "./codegen.ts";
+export type { GenerateOptions } from "./codegen.ts";
 export { transform } from "./transform.ts";
 export { run } from "./run.ts";
 export type { RunOptions, RunResult, RegistryLike } from "./run.ts";

--- a/packages/jth-compiler/src/run.ts
+++ b/packages/jth-compiler/src/run.ts
@@ -35,6 +35,12 @@ export interface RunOptions {
   timeoutMs?: number;
   /** Capture console.log lines emitted during execution. */
   captureLog?: boolean;
+  /**
+   * Reject inline JS (`((...))`) at compile time with OP_NOT_ALLOWED.
+   * Sandboxed consumers (jth-eval) set this: inline JS trivially escapes
+   * any operator allowlist.
+   */
+  forbidInlineJS?: boolean;
 }
 
 export interface RunResult {
@@ -57,9 +63,10 @@ export async function run(source: string, opts: RunOptions = {}): Promise<RunRes
     stack = new Stack(),
     timeoutMs = 0,
     captureLog = false,
+    forbidInlineJS = false,
   } = opts;
 
-  const js = transform(source, { preamble: false });
+  const js = transform(source, { preamble: false, forbidInlineJS });
 
   // The generated code references `stack`, `processN`, and `registry`.
   // Wrap in an async IIFE so top-level `await processN(...)` works.

--- a/packages/jth-compiler/src/transform.ts
+++ b/packages/jth-compiler/src/transform.ts
@@ -4,11 +4,12 @@
 import { lex } from "./lexer.ts";
 import { parse } from "./parser.ts";
 import { generate } from "./codegen.ts";
+import type { GenerateOptions } from "./codegen.ts";
 
 /**
  * Transform jth source code into JavaScript.
  */
-export function transform(source: string, options: { preamble?: boolean } = {}): string {
+export function transform(source: string, options: GenerateOptions = {}): string {
   const tokens = lex(source);
   const ast = parse(tokens);
   return generate(ast, options);

--- a/packages/jth-compiler/tsconfig.build.json
+++ b/packages/jth-compiler/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declarationMap": false,
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/jth-compiler/tsup.config.ts
+++ b/packages/jth-compiler/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    "index": "src/index.ts",
+    "lexer": "src/lexer.ts",
+    "parser": "src/parser.ts",
+    "codegen": "src/codegen.ts",
+    "transform": "src/transform.ts",
+    "run": "src/run.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  target: "node20",
+  platform: "node",
+  tsconfig: "tsconfig.build.json",
+});

--- a/packages/jth-eval/README.md
+++ b/packages/jth-eval/README.md
@@ -1,0 +1,76 @@
+# jth-eval
+
+Embeddable jth evaluation for JavaScript hosts: one-shot `evalJth()`, a persistent `JthContext`, and a `ScopedRegistry` that lets each evaluation define/override operators without touching the global registry. Execution goes through the shared `jth-compiler` `run()` pipeline.
+
+## Installation
+
+```bash
+npm install jth-eval
+```
+
+## `evalJth(code, options?)`
+
+One-shot evaluation. Returns `{ value, stack, output }` — top of stack, full stack array, and captured `console.log` output.
+
+```ts
+import { evalJth } from "jth-eval";
+
+const { value } = await evalJth("1 2 +;");            // 3
+const r = await evalJth("x y +;", { values: { x: 10, y: 20 } }); // 30
+```
+
+Options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `values` | `Record<string, unknown>` | `{}` | Injected as zero-arity operators |
+| `operators` | `Record<string, StackOperator>` | `{}` | Custom operators (build with `op(arity)(fn)` from jth-runtime) |
+| `stack` | `unknown[]` | `[]` | Pre-load the stack |
+| `timeout` | `number` | `5000` | Max execution time in ms (rejects on expiry) |
+| `sandbox` | `boolean \| "restricted" \| string[]` | `false` | See below |
+| `captureOutput` | `boolean` | `true` | Capture `console.log` into `result.output` |
+
+## Sandbox modes
+
+| Value | Meaning |
+|-------|---------|
+| `false` | Full access to every registered operator |
+| `true` | Bare mode: only injected `values`/`operators` resolve; all stdlib blocked |
+| `"restricted"` | **Currently a no-op** — grants full access (see limitation below) |
+| `string[]` | Explicit allowlist of global operator names |
+
+Blocked operators throw `JthRuntimeError` (`code: "SANDBOX_DENIED"`); unknown names throw `code: "UNKNOWN_OPERATOR"`.
+
+> **Known limitation ([#22](https://github.com/johnhenry/jth/issues/22)):** `"restricted"` mode does not yet restrict anything — the restricted-op set is empty and the mode falls back to full access. Inline JS (`((...))`) is also not blocked in any sandbox mode. Do not rely on the sandbox for isolation of untrusted code yet.
+
+## `JthContext`
+
+Persistent stack + registry across multiple `eval()` calls.
+
+```ts
+import { JthContext } from "jth-eval";
+
+const ctx = new JthContext({ timeout: 2000 });
+await ctx.eval("1 2 +;");
+await ctx.eval("10 *;");
+ctx.pop();               // 30
+ctx.define("pi", 3.14159);          // named value
+ctx.defineOp("add", 2, (a, b) => a + b); // custom op
+ctx.dispose();           // further use throws CONTEXT_DISPOSED
+```
+
+Also on the context: `push(...)`, `pop()`, `peek()`, `clear()`, `toArray()`, `length`.
+
+## `ScopedRegistry`
+
+Local overlay over the global operator registry: writes stay local, reads fall back to global (optionally filtered through an allowlist). Useful for building your own evaluation environments.
+
+```ts
+import { ScopedRegistry } from "jth-eval";
+const reg = new ScopedRegistry({ allowlist: new Set(["+", "-"]) });
+```
+
+## Notes
+
+- Importing `jth-eval` loads `jth-stdlib` (registers the standard library globally).
+- Timeouts use `Promise.race` — a timed-out evaluation rejects, but a hot synchronous loop cannot be preempted mid-statement.

--- a/packages/jth-eval/README.md
+++ b/packages/jth-eval/README.md
@@ -34,14 +34,26 @@ Options:
 
 | Value | Meaning |
 |-------|---------|
-| `false` | Full access to every registered operator |
+| `false` | Full access to every registered operator, inline JS allowed |
 | `true` | Bare mode: only injected `values`/`operators` resolve; all stdlib blocked |
-| `"restricted"` | **Currently a no-op** — grants full access (see limitation below) |
+| `"restricted"` | All statically registered pure ops allowed; side-effecting ops blocked (see policy) |
 | `string[]` | Explicit allowlist of global operator names |
 
-Blocked operators throw `JthRuntimeError` (`code: "SANDBOX_DENIED"`); unknown names throw `code: "UNKNOWN_OPERATOR"`.
+Blocked operators throw `JthRuntimeError` with `code: "OP_NOT_ALLOWED"`; unknown names throw `code: "UNKNOWN_OPERATOR"`.
 
-> **Known limitation ([#22](https://github.com/johnhenry/jth/issues/22)):** `"restricted"` mode does not yet restrict anything — the restricted-op set is empty and the mode falls back to full access. Inline JS (`((...))`) is also not blocked in any sandbox mode. Do not rely on the sandbox for isolation of untrusted code yet.
+### Restricted-mode policy (default-deny)
+
+- The allowlist is built by enumerating the registry (`registry.names()`) and removing `RESTRICTED_OPS` — the ops that touch the world outside the evaluation. In the default stdlib that is the console I/O pair **`peek` / `peek-all`**.
+- **Inline JS (`((...))`) is rejected at compile time** in *every* sandbox mode (`true`, `"restricted"`, and array allowlists) — it would trivially escape any operator allowlist. The whole program is rejected before any statement runs.
+- **Dynamic pattern ops** (`3+`, `2log`, `***`, …) are denied in restricted mode: patterns match open-ended name families and cannot be enumerated into an allowlist.
+
+```ts
+await evalJth("1 2 +;", { sandbox: "restricted" });      // ok → 3
+await evalJth('"hi" peek;', { sandbox: "restricted" });  // throws OP_NOT_ALLOWED
+await evalJth("((s)=>s.push(1));", { sandbox: "restricted" }); // throws OP_NOT_ALLOWED (compile time)
+```
+
+> The sandbox restricts which *operators* a program may call and blocks inline JS. It is not an OS-level isolation boundary: evaluation still runs in-process with host JS semantics (e.g. no memory limits, and a hot synchronous loop can only be cut off at statement boundaries by the timeout).
 
 ## `JthContext`
 

--- a/packages/jth-eval/__tests__/context.test.ts
+++ b/packages/jth-eval/__tests__/context.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { JthContext } from "../src/context.mjs";
+import { JthContext } from "../src/context.ts";
 
 describe("JthContext", () => {
   let ctx;

--- a/packages/jth-eval/__tests__/eval.test.ts
+++ b/packages/jth-eval/__tests__/eval.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { op, variadic } from "jth-runtime";
-import { evalJth } from "../src/eval.mjs";
+import { evalJth } from "../src/eval.ts";
 
 describe("evalJth", () => {
   describe("basic evaluation", () => {

--- a/packages/jth-eval/__tests__/sandbox.test.ts
+++ b/packages/jth-eval/__tests__/sandbox.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { evalJth } from "../src/eval.mjs";
-import { JthContext } from "../src/context.mjs";
+import { evalJth } from "../src/eval.ts";
+import { JthContext } from "../src/context.ts";
 
 describe("Sandbox modes", () => {
   describe("sandbox: false (default, full access)", () => {

--- a/packages/jth-eval/__tests__/sandbox.test.ts
+++ b/packages/jth-eval/__tests__/sandbox.test.ts
@@ -72,6 +72,109 @@ describe("Sandbox modes", () => {
       });
       expect(result.value).toBe("yes");
     });
+
+    it("allows map (pure higher-order ops)", async () => {
+      const result = await evalJth("[1 2 3] #[ 2 * ] map;", {
+        sandbox: "restricted",
+      });
+      expect(result.value).toEqual([2, 4, 6]);
+    });
+
+    it("blocks the console I/O op `peek` with OP_NOT_ALLOWED", async () => {
+      await expect(
+        evalJth('"hi" peek;', { sandbox: "restricted" })
+      ).rejects.toMatchObject({
+        code: "OP_NOT_ALLOWED",
+        message: expect.stringContaining("peek"),
+      });
+    });
+
+    it("blocks `peek-all` with OP_NOT_ALLOWED", async () => {
+      await expect(
+        evalJth("1 2 peek-all;", { sandbox: "restricted" })
+      ).rejects.toMatchObject({ code: "OP_NOT_ALLOWED" });
+    });
+
+    it("without sandbox, peek is allowed (control test)", async () => {
+      const result = await evalJth('"hi" peek;', { sandbox: false });
+      expect(result.output).toBe("hi");
+    });
+
+    it("blocks dynamic pattern ops (not enumerable into the allowlist)", async () => {
+      // "3+" resolves via a dynamic registry pattern in open mode...
+      const open = await evalJth("4 3+;", { sandbox: false });
+      expect(open.value).toBe(7);
+      // ...but restricted mode default-denies anything not statically named.
+      await expect(
+        evalJth("4 3+;", { sandbox: "restricted" })
+      ).rejects.toMatchObject({ code: "OP_NOT_ALLOWED" });
+    });
+
+    it("blocks inline JS at compile time with OP_NOT_ALLOWED", async () => {
+      // Control: inline JS runs in open mode.
+      const open = await evalJth("((s) => { s.push(42); });", {
+        sandbox: false,
+      });
+      expect(open.value).toBe(42);
+      await expect(
+        evalJth("((s) => { s.push(42); });", { sandbox: "restricted" })
+      ).rejects.toMatchObject({
+        code: "OP_NOT_ALLOWED",
+        message: expect.stringContaining("Inline JS"),
+      });
+    });
+
+    it("blocked programs do not execute at all (no partial effects)", async () => {
+      // The inline JS appears after a valid statement; compile-time
+      // rejection means even the first statement must not run.
+      let leaked = false;
+      const { op } = await import("jth-runtime");
+      const markLeak = op(0)(() => {
+        leaked = true;
+        return [];
+      });
+      await expect(
+        evalJth("mark-leak; ((s) => s.push(1));", {
+          sandbox: "restricted",
+          operators: { "mark-leak": markLeak },
+        })
+      ).rejects.toMatchObject({ code: "OP_NOT_ALLOWED" });
+      expect(leaked).toBe(false);
+    });
+  });
+
+  describe("inline JS is blocked in every sandbox mode", () => {
+    it("sandbox: true blocks inline JS", async () => {
+      await expect(
+        evalJth("((s) => s.push(1));", { sandbox: true })
+      ).rejects.toMatchObject({ code: "OP_NOT_ALLOWED" });
+    });
+
+    it("sandbox: string[] blocks inline JS", async () => {
+      await expect(
+        evalJth("((s) => s.push(1));", { sandbox: ["+"] })
+      ).rejects.toMatchObject({ code: "OP_NOT_ALLOWED" });
+    });
+
+    it("JthContext restricted mode blocks inline JS", async () => {
+      const ctx = new JthContext({ sandbox: "restricted" });
+      await expect(ctx.eval("((s) => s.push(1));")).rejects.toMatchObject({
+        code: "OP_NOT_ALLOWED",
+      });
+      ctx.dispose();
+    });
+  });
+
+  describe("JthContext restricted mode", () => {
+    it("allows pure ops, blocks peek", async () => {
+      const ctx = new JthContext({ sandbox: "restricted" });
+      const result = await ctx.eval("2 3 +;");
+      expect(result.value).toBe(5);
+      await expect(ctx.eval("peek;")).rejects.toMatchObject({
+        code: "OP_NOT_ALLOWED",
+      });
+      ctx.dispose();
+    });
   });
 
   describe("sandbox: string[] (explicit allowlist)", () => {

--- a/packages/jth-eval/__tests__/scoped-registry.test.ts
+++ b/packages/jth-eval/__tests__/scoped-registry.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { registry } from "jth-runtime";
 import "jth-stdlib";
-import { ScopedRegistry } from "../src/scoped-registry.mjs";
+import { ScopedRegistry } from "../src/scoped-registry.ts";
 
 describe("ScopedRegistry", () => {
   let scoped;

--- a/packages/jth-eval/package.json
+++ b/packages/jth-eval/package.json
@@ -34,5 +34,6 @@
     "jth-compiler": "^0.4.0",
     "jth-runtime": "^0.4.0",
     "jth-stdlib": "^0.4.0"
-  }
+  },
+  "license": "MIT"
 }

--- a/packages/jth-eval/package.json
+++ b/packages/jth-eval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jth-eval",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,9 +30,9 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "jth-types": "0.3.0",
-    "jth-compiler": "0.3.0",
-    "jth-runtime": "0.3.0",
-    "jth-stdlib": "0.3.0"
+    "jth-types": "^0.4.0",
+    "jth-compiler": "^0.4.0",
+    "jth-runtime": "^0.4.0",
+    "jth-stdlib": "^0.4.0"
   }
 }

--- a/packages/jth-eval/package.json
+++ b/packages/jth-eval/package.json
@@ -2,7 +2,13 @@
   "name": "jth-eval",
   "version": "0.3.0",
   "type": "module",
-  "main": "src/index.mjs",
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./eval": "./src/eval.ts",
+    "./context": "./src/context.ts",
+    "./scoped-registry": "./src/scoped-registry.ts"
+  },
   "dependencies": {
     "jth-types": "0.3.0",
     "jth-compiler": "0.3.0",

--- a/packages/jth-eval/package.json
+++ b/packages/jth-eval/package.json
@@ -2,12 +2,32 @@
   "name": "jth-eval",
   "version": "0.3.0",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./eval": "./src/eval.ts",
-    "./context": "./src/context.ts",
-    "./scoped-registry": "./src/scoped-registry.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./eval": {
+      "types": "./dist/eval.d.ts",
+      "default": "./dist/eval.js"
+    },
+    "./context": {
+      "types": "./dist/context.d.ts",
+      "default": "./dist/context.js"
+    },
+    "./scoped-registry": {
+      "types": "./dist/scoped-registry.d.ts",
+      "default": "./dist/scoped-registry.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "jth-types": "0.3.0",

--- a/packages/jth-eval/src/context.ts
+++ b/packages/jth-eval/src/context.ts
@@ -2,33 +2,37 @@ import { Stack, op } from "jth-runtime";
 import { JthRuntimeError } from "jth-types";
 import { run } from "jth-compiler";
 import "jth-stdlib";
-import { ScopedRegistry } from "./scoped-registry.mjs";
+import { ScopedRegistry } from "./scoped-registry.ts";
+import type { SandboxOption, EvalResult } from "./eval.ts";
+
+export interface JthContextOptions {
+  /** Default max execution time in ms (default: 5000). */
+  timeout?: number;
+  /** Control stdlib availability. */
+  sandbox?: SandboxOption;
+  /** Capture output (default: true). */
+  captureOutput?: boolean;
+}
 
 /**
  * Persistent jth evaluation context.
  * Maintains stack and registry state across multiple eval() calls.
  */
 export class JthContext {
-  #stack;
-  #registry;
-  #timeout;
-  #captureOutput;
+  #stack: Stack;
+  #registry: ScopedRegistry;
+  #timeout: number;
+  #captureOutput: boolean;
   #disposed = false;
 
-  /**
-   * @param {object} [options]
-   * @param {number} [options.timeout] - Default max execution time in ms (default: 5000)
-   * @param {boolean|"restricted"|string[]} [options.sandbox] - Control stdlib availability
-   * @param {boolean} [options.captureOutput] - Capture output (default: true)
-   */
-  constructor(options = {}) {
+  constructor(options: JthContextOptions = {}) {
     const { timeout = 5000, sandbox = false, captureOutput = true } = options;
     this.#timeout = timeout;
     this.#captureOutput = captureOutput;
     this.#stack = new Stack();
 
     // Build allowlist if sandbox mode is set
-    let allowlist = null;
+    let allowlist: Set<string> | null = null;
     if (sandbox === true) {
       allowlist = new Set();
     } else if (sandbox === "restricted") {
@@ -43,12 +47,11 @@ export class JthContext {
 
   /**
    * Evaluate jth code using the persistent stack and registry.
-   * @param {string} code - jth source code
-   * @param {object} [options]
-   * @param {number} [options.timeout] - Override timeout for this evaluation
-   * @returns {Promise<{value: any, stack: any[], output: string}>}
    */
-  async eval(code, options = {}) {
+  async eval(
+    code: string,
+    options: { timeout?: number } = {}
+  ): Promise<EvalResult> {
     this.#assertNotDisposed();
     const timeout = options.timeout ?? this.#timeout;
 
@@ -71,26 +74,26 @@ export class JthContext {
   /**
    * Define a named value as a zero-arity operator.
    */
-  define(name, value) {
+  define(name: string, value: unknown): void {
     this.#assertNotDisposed();
     this.#registry.set(name, op(0)(() => [value]));
   }
 
   /**
    * Define a custom operator with fixed arity.
-   * @param {string} name - Operator name
-   * @param {number} arity - Number of stack items to consume
-   * @param {Function} fn - Function receiving `arity` args, returns single value
+   * @param name - Operator name
+   * @param arity - Number of stack items to consume
+   * @param fn - Function receiving `arity` args, returns single value
    */
-  defineOp(name, arity, fn) {
+  defineOp(name: string, arity: number, fn: (...args: any[]) => unknown): void {
     this.#assertNotDisposed();
-    this.#registry.set(name, op(arity)((...args) => [fn(...args)]));
+    this.#registry.set(name, op(arity)((...args: unknown[]) => [fn(...args)]));
   }
 
   /**
    * Push values onto the stack.
    */
-  push(...values) {
+  push(...values: unknown[]): void {
     this.#assertNotDisposed();
     this.#stack.push(...values);
   }
@@ -98,7 +101,7 @@ export class JthContext {
   /**
    * Pop and return the top value from the stack.
    */
-  pop() {
+  pop(): unknown {
     this.#assertNotDisposed();
     return this.#stack.pop();
   }
@@ -106,7 +109,7 @@ export class JthContext {
   /**
    * Peek at the top value without removing it.
    */
-  peek() {
+  peek(): unknown {
     this.#assertNotDisposed();
     return this.#stack.peek();
   }
@@ -114,7 +117,7 @@ export class JthContext {
   /**
    * Clear the stack.
    */
-  clear() {
+  clear(): void {
     this.#assertNotDisposed();
     this.#stack.clear();
   }
@@ -122,7 +125,7 @@ export class JthContext {
   /**
    * Get the stack contents as an array.
    */
-  toArray() {
+  toArray(): unknown[] {
     this.#assertNotDisposed();
     return this.#stack.toArray();
   }
@@ -130,7 +133,7 @@ export class JthContext {
   /**
    * Get the current stack length.
    */
-  get length() {
+  get length(): number {
     this.#assertNotDisposed();
     return this.#stack.length;
   }
@@ -138,13 +141,13 @@ export class JthContext {
   /**
    * Clean up the context.
    */
-  dispose() {
+  dispose(): void {
     this.#stack.clear();
     this.#registry.clear();
     this.#disposed = true;
   }
 
-  #assertNotDisposed() {
+  #assertNotDisposed(): void {
     if (this.#disposed) {
       throw new JthRuntimeError(
         "JthContext has been disposed",

--- a/packages/jth-eval/src/context.ts
+++ b/packages/jth-eval/src/context.ts
@@ -3,6 +3,7 @@ import { JthRuntimeError } from "jth-types";
 import { run } from "jth-compiler";
 import "jth-stdlib";
 import { ScopedRegistry } from "./scoped-registry.ts";
+import { buildAllowlist } from "./eval.ts";
 import type { SandboxOption, EvalResult } from "./eval.ts";
 
 export interface JthContextOptions {
@@ -23,6 +24,7 @@ export class JthContext {
   #registry: ScopedRegistry;
   #timeout: number;
   #captureOutput: boolean;
+  #forbidInlineJS: boolean;
   #disposed = false;
 
   constructor(options: JthContextOptions = {}) {
@@ -31,17 +33,10 @@ export class JthContext {
     this.#captureOutput = captureOutput;
     this.#stack = new Stack();
 
-    // Build allowlist if sandbox mode is set
-    let allowlist: Set<string> | null = null;
-    if (sandbox === true) {
-      allowlist = new Set();
-    } else if (sandbox === "restricted") {
-      // All stdlib names (restricted ops excluded — none currently)
-      allowlist = null; // full access for now, since no restricted ops exist
-    } else if (Array.isArray(sandbox)) {
-      allowlist = new Set(sandbox);
-    }
-
+    // Sandbox: shared allowlist policy (see eval.ts). In any sandbox mode,
+    // inline JS is rejected at compile time — it escapes the allowlist.
+    const allowlist = buildAllowlist(sandbox);
+    this.#forbidInlineJS = sandbox !== false;
     this.#registry = new ScopedRegistry({ allowlist });
   }
 
@@ -62,6 +57,7 @@ export class JthContext {
       registry: this.#registry,
       timeoutMs: timeout,
       captureLog: this.#captureOutput,
+      forbidInlineJS: this.#forbidInlineJS,
     });
 
     return {

--- a/packages/jth-eval/src/eval.ts
+++ b/packages/jth-eval/src/eval.ts
@@ -4,9 +4,29 @@ import { run } from "jth-compiler";
 import "jth-stdlib";
 import { ScopedRegistry } from "./scoped-registry.ts";
 
-// Operators considered IO/shell/network for "restricted" sandbox mode.
-// Currently jth-stdlib has no such operators, but this future-proofs the list.
-const RESTRICTED_OPS = new Set<string>([]);
+/**
+ * Restricted-op policy for `sandbox: "restricted"`:
+ *
+ * The allowlist is built from `registry.names()` (every statically
+ * registered operator) MINUS this set. Excluded here is every op that
+ * touches the world outside the evaluation (I/O, process, network,
+ * filesystem). jth-stdlib is almost entirely pure/computational; its only
+ * side-effecting ops are the console printers:
+ *
+ *   - `peek` / `peek-all` — write to the host console (console.log)
+ *
+ * Additionally, and independently of this set:
+ *   - Inline JS (`((...))`) is rejected at compile time in every sandbox
+ *     mode (it escapes any allowlist) — see forbidInlineJS below.
+ *   - Dynamic pattern ops (e.g. "3+", "2log", "***") are default-denied
+ *     in restricted mode because patterns cannot be enumerated into an
+ *     allowlist. Only the statically named ops resolve.
+ *
+ * If an op package that performs I/O or network access (none in the
+ * default registry today; jth-ai deliberately registers no jth words)
+ * ever registers globally, its op names must be added here.
+ */
+const RESTRICTED_OPS = new Set<string>(["peek", "peek-all"]);
 
 export type SandboxOption = boolean | "restricted" | string[];
 
@@ -76,11 +96,14 @@ export async function evalJth(
 
   // Execute through the shared jth-compiler run() pipeline, passing the
   // sandbox registry, timeout, and output capture through RunOptions.
+  // In any sandbox mode, inline JS is rejected at compile time — it would
+  // trivially escape the operator allowlist.
   const { value, output } = await run(code, {
     stack,
     registry: scopedRegistry,
     timeoutMs: timeout,
     captureLog: captureOutput,
+    forbidInlineJS: sandbox !== false,
   });
 
   return {
@@ -92,8 +115,9 @@ export async function evalJth(
 
 /**
  * Build an allowlist Set for sandbox mode, or null for no filtering.
+ * Shared by evalJth and JthContext.
  */
-function buildAllowlist(sandbox: SandboxOption): Set<string> | null {
+export function buildAllowlist(sandbox: SandboxOption): Set<string> | null {
   if (sandbox === false) return null; // Full access
 
   if (sandbox === true) {
@@ -102,9 +126,10 @@ function buildAllowlist(sandbox: SandboxOption): Set<string> | null {
   }
 
   if (sandbox === "restricted") {
-    // All stdlib minus restricted ops — collect all registered names
-    // and exclude RESTRICTED_OPS
-    const all = collectGlobalNames();
+    // Default-deny: every statically registered op name, minus the
+    // restricted (side-effecting) set. Dynamic pattern ops are not
+    // enumerable and therefore stay denied.
+    const all = new Set(registry.names());
     for (const name of RESTRICTED_OPS) {
       all.delete(name);
     }
@@ -117,66 +142,4 @@ function buildAllowlist(sandbox: SandboxOption): Set<string> | null {
   }
 
   return null;
-}
-
-/**
- * Collect all currently registered operator names from the global registry.
- * We probe known operator names since the registry doesn't expose iteration.
- */
-function collectGlobalNames(): Set<string> {
-  // We'll use a known comprehensive list of all stdlib operators
-  const names = [
-    // Stack ops
-    "noop", "∅", "clear", "...", "spread", "drop", "dupe", "dup", "copy",
-    "swap", "reverse", "count", "depth", "collect", "peek", "peek-all",
-    "apply", "exec", "over", "rot",
-    // Arithmetic
-    "+", "-", "*", "⋅", "/", "÷", "**", "%", "%%", "++", "--",
-    "Σ", "Π", "abs", "|𝑥|", "√", "sqrt",
-    "floor", "ceil", "round", "trunc", "log", "min", "max",
-    "plus", "minus", "mul", "div", "mod", "pow",
-    // Comparison
-    "=", "==", "<", "<=", ">", ">=", "<=>",
-    "eq?", "ne?", "!=", "lt?", "le?", "gt?", "ge?",
-    // Logic
-    "&&", "||", "xor", "nand", "nor", "~~", "not",
-    // Control flow
-    "if", "elseif", "else", "when", "drop-when", "keep-if", "drop-if",
-    "times", "while", "until", "break",
-    // Error handling
-    "try", "throw", "error?",
-    // String ops
-    "len", "upper", "lower", "trim", "strcat", "strseq",
-    "startsWith", "endsWith", "indexOf", "starts?", "ends?", "index-of",
-    // Type ops
-    "typeof", "number?", "string?", "array?", "nil?", "function?",
-    "empty?", "contains?",
-    // Serialization
-    "into-json", "to-json", "from-json", "into-lines", "from-lines", "to-lines",
-    // Array ops
-    "push", "pop", "shift", "unshift", "suppose", "flatten",
-    "map", "filter", "reduce", "fold", "bend",
-    // Dict ops
-    "keys", "values", "entries", "merge", "record",
-    // Combinators
-    "each", "fanout", "zip", "compose",
-    // Async ops
-    "_", "__",
-    // Meta ops
-    "$", "$$", "<<-", "->>",
-    // Iterator ops
-    "next", "iter", "..",
-    // Sequences
-    "fibonacci",
-    // Statistics
-    "x̄", "mean", "median", "mode", "modes",
-  ];
-
-  const found = new Set<string>();
-  for (const name of names) {
-    if (registry.has(name)) {
-      found.add(name);
-    }
-  }
-  return found;
 }

--- a/packages/jth-eval/src/eval.ts
+++ b/packages/jth-eval/src/eval.ts
@@ -1,26 +1,46 @@
 import { Stack, registry, op } from "jth-runtime";
+import type { StackOperator } from "jth-runtime";
 import { run } from "jth-compiler";
 import "jth-stdlib";
-import { ScopedRegistry } from "./scoped-registry.mjs";
+import { ScopedRegistry } from "./scoped-registry.ts";
 
 // Operators considered IO/shell/network for "restricted" sandbox mode.
 // Currently jth-stdlib has no such operators, but this future-proofs the list.
-const RESTRICTED_OPS = new Set([]);
+const RESTRICTED_OPS = new Set<string>([]);
+
+export type SandboxOption = boolean | "restricted" | string[];
+
+export interface EvalOptions {
+  /** Named values injected as zero-arity operators. */
+  values?: Record<string, unknown>;
+  /** Custom operator functions. */
+  operators?: Record<string, StackOperator>;
+  /** Pre-load the stack before evaluation. */
+  stack?: unknown[];
+  /** Max execution time in ms (default: 5000). */
+  timeout?: number;
+  /** Control stdlib availability. */
+  sandbox?: SandboxOption;
+  /** Capture console.log output (default: true). */
+  captureOutput?: boolean;
+}
+
+export interface EvalResult {
+  /** Top of the stack after execution (undefined if empty). */
+  value: unknown;
+  /** Full stack contents after execution. */
+  stack: unknown[];
+  /** Captured console output ("" unless captureOutput). */
+  output: string;
+}
 
 /**
  * One-shot jth evaluation.
- *
- * @param {string} code - jth source code to evaluate
- * @param {object} [options]
- * @param {Record<string, any>} [options.values] - Named values injected as zero-arity operators
- * @param {Record<string, Function>} [options.operators] - Custom operator functions
- * @param {any[]} [options.stack] - Pre-load the stack before evaluation
- * @param {number} [options.timeout] - Max execution time in ms (default: 5000)
- * @param {boolean|"restricted"|string[]} [options.sandbox] - Control stdlib availability
- * @param {boolean} [options.captureOutput] - Capture console.log output (default: true)
- * @returns {Promise<EvalResult>}
  */
-export async function evalJth(code, options = {}) {
+export async function evalJth(
+  code: string,
+  options: EvalOptions = {}
+): Promise<EvalResult> {
   const {
     values = {},
     operators = {},
@@ -73,7 +93,7 @@ export async function evalJth(code, options = {}) {
 /**
  * Build an allowlist Set for sandbox mode, or null for no filtering.
  */
-function buildAllowlist(sandbox) {
+function buildAllowlist(sandbox: SandboxOption): Set<string> | null {
   if (sandbox === false) return null; // Full access
 
   if (sandbox === true) {
@@ -103,16 +123,16 @@ function buildAllowlist(sandbox) {
  * Collect all currently registered operator names from the global registry.
  * We probe known operator names since the registry doesn't expose iteration.
  */
-function collectGlobalNames() {
+function collectGlobalNames(): Set<string> {
   // We'll use a known comprehensive list of all stdlib operators
   const names = [
     // Stack ops
-    "noop", "\u2205", "clear", "...", "spread", "drop", "dupe", "dup", "copy",
+    "noop", "∅", "clear", "...", "spread", "drop", "dupe", "dup", "copy",
     "swap", "reverse", "count", "depth", "collect", "peek", "peek-all",
     "apply", "exec", "over", "rot",
     // Arithmetic
-    "+", "-", "*", "\u22C5", "/", "\u00F7", "**", "%", "%%", "++", "--",
-    "\u03A3", "\u03A0", "abs", "|\uD835\uDC65|", "\u221A", "sqrt",
+    "+", "-", "*", "⋅", "/", "÷", "**", "%", "%%", "++", "--",
+    "Σ", "Π", "abs", "|𝑥|", "√", "sqrt",
     "floor", "ceil", "round", "trunc", "log", "min", "max",
     "plus", "minus", "mul", "div", "mod", "pow",
     // Comparison
@@ -149,10 +169,10 @@ function collectGlobalNames() {
     // Sequences
     "fibonacci",
     // Statistics
-    "x\u0304", "mean", "median", "mode", "modes",
+    "x̄", "mean", "median", "mode", "modes",
   ];
 
-  const found = new Set();
+  const found = new Set<string>();
   for (const name of names) {
     if (registry.has(name)) {
       found.add(name);

--- a/packages/jth-eval/src/index.mjs
+++ b/packages/jth-eval/src/index.mjs
@@ -1,3 +1,0 @@
-export { evalJth } from "./eval.mjs";
-export { JthContext } from "./context.mjs";
-export { ScopedRegistry } from "./scoped-registry.mjs";

--- a/packages/jth-eval/src/index.ts
+++ b/packages/jth-eval/src/index.ts
@@ -1,0 +1,6 @@
+export { evalJth } from "./eval.ts";
+export type { EvalOptions, EvalResult, SandboxOption } from "./eval.ts";
+export { JthContext } from "./context.ts";
+export type { JthContextOptions } from "./context.ts";
+export { ScopedRegistry } from "./scoped-registry.ts";
+export type { ScopedRegistryOptions } from "./scoped-registry.ts";

--- a/packages/jth-eval/src/scoped-registry.ts
+++ b/packages/jth-eval/src/scoped-registry.ts
@@ -1,5 +1,19 @@
 import { registry } from "jth-runtime";
+import type { StackOperator } from "jth-runtime";
 import { JthRuntimeError } from "jth-types";
+
+type DynamicFactory = (
+  name: string,
+  pattern: RegExp
+) => StackOperator | undefined;
+
+export interface ScopedRegistryOptions {
+  /**
+   * If set, only these operator names are allowed to resolve from the
+   * global registry. null = allow all.
+   */
+  allowlist?: Set<string> | null;
+}
 
 /**
  * ScopedRegistry wraps the global registry with a local overlay.
@@ -7,16 +21,11 @@ import { JthRuntimeError } from "jth-types";
  * to the global registry. Sandbox mode filters global fallback through an allowlist.
  */
 export class ScopedRegistry {
-  #local = new Map();
-  #dynamicLocal = [];
-  #allowlist = null; // null = no filtering, Set = only these names allowed from global
+  #local = new Map<string, StackOperator>();
+  #dynamicLocal: Array<{ pattern: RegExp; factory: DynamicFactory }> = [];
+  #allowlist: Set<string> | null = null; // null = no filtering, Set = only these names allowed from global
 
-  /**
-   * @param {object} [options]
-   * @param {Set<string>|null} [options.allowlist] - If set, only these operator names
-   *   are allowed to resolve from the global registry. null = allow all.
-   */
-  constructor(options = {}) {
+  constructor(options: ScopedRegistryOptions = {}) {
     if (options.allowlist) {
       this.#allowlist = options.allowlist;
     }
@@ -25,7 +34,7 @@ export class ScopedRegistry {
   /**
    * Register an operator in the local scope.
    */
-  set(name, fn) {
+  set(name: string, fn: StackOperator): void {
     this.#local.set(name, fn);
   }
 
@@ -33,7 +42,7 @@ export class ScopedRegistry {
    * Get an operator. Checks local first, then global (with allowlist filtering).
    * Returns undefined if not found.
    */
-  get(name) {
+  get(name: string): StackOperator | undefined {
     if (this.#local.has(name)) return this.#local.get(name);
 
     // Check local dynamic patterns
@@ -51,7 +60,7 @@ export class ScopedRegistry {
   /**
    * Get an operator or throw if not found.
    */
-  resolve(name) {
+  resolve(name: string): StackOperator {
     const fn = this.get(name);
     if (!fn) {
       if (this.#allowlist && !this.#allowlist.has(name) && registry.has(name)) {
@@ -75,28 +84,28 @@ export class ScopedRegistry {
   /**
    * Check if an operator exists (local or allowed global).
    */
-  has(name) {
+  has(name: string): boolean {
     return this.get(name) !== undefined;
   }
 
   /**
    * Remove an operator from the local scope only.
    */
-  remove(name) {
+  remove(name: string): boolean {
     return this.#local.delete(name);
   }
 
   /**
    * Register a dynamic pattern in the local scope.
    */
-  setDynamic(pattern, factory) {
+  setDynamic(pattern: RegExp, factory: DynamicFactory): void {
     this.#dynamicLocal.push({ pattern, factory });
   }
 
   /**
    * Clear the local scope only. Does not affect global registry.
    */
-  clear() {
+  clear(): void {
     this.#local.clear();
     this.#dynamicLocal.length = 0;
   }

--- a/packages/jth-eval/src/scoped-registry.ts
+++ b/packages/jth-eval/src/scoped-registry.ts
@@ -68,7 +68,7 @@ export class ScopedRegistry {
           `Operator not allowed in sandbox: ${name}`,
           undefined,
           undefined,
-          "SANDBOX_DENIED"
+          "OP_NOT_ALLOWED"
         );
       }
       throw new JthRuntimeError(

--- a/packages/jth-eval/tsconfig.build.json
+++ b/packages/jth-eval/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declarationMap": false,
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/jth-eval/tsconfig.json
+++ b/packages/jth-eval/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"],
+  "references": [
+    { "path": "../jth-types" },
+    { "path": "../jth-runtime" },
+    { "path": "../jth-compiler" },
+    { "path": "../jth-stdlib" }
+  ]
+}

--- a/packages/jth-eval/tsup.config.ts
+++ b/packages/jth-eval/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    "index": "src/index.ts",
+    "eval": "src/eval.ts",
+    "context": "src/context.ts",
+    "scoped-registry": "src/scoped-registry.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  target: "node20",
+  platform: "node",
+  tsconfig: "tsconfig.build.json",
+});

--- a/packages/jth-html/README.md
+++ b/packages/jth-html/README.md
@@ -1,0 +1,60 @@
+# jth-html
+
+HTML DSL for jth: build HTML trees on the stack and render them to strings. Importing the package registers its operators with the global jth-runtime registry as a side effect.
+
+## Installation
+
+```bash
+npm install jth-html
+```
+
+## Loading the ops (opt-in)
+
+The compiler preamble only auto-loads `jth-stdlib` — the `h-*` ops are **not** available by default. A `.jth` program opts in with an import directive, which the compiler passes through so the package registers its ops at module load:
+
+```jth
+::import "jth-html";
+
+#[ "Hello" h-text ] "h1" h-tag h-render peek;
+```
+
+```bash
+jth run page.jth
+# <h1>Hello</h1>
+```
+
+From JavaScript, `import "jth-html"` (or call `registerHTML()` explicitly).
+
+## Registered operators
+
+| Operator | Stack effect | Description |
+|----------|--------------|-------------|
+| `h-tag` | `block "tag"` → `element` | Executes the block on a child stack; its items become children |
+| `h-text` | `value` → `textNode` | Text node (HTML-escaped on render) |
+| `h-raw` | `value` → `rawNode` | Raw HTML, rendered without escaping |
+| `h-frag` | `block` → `fragment` | Fragment: children render with no wrapper tag |
+| `h-void` | `"tag"` → `element` | Element with no children (e.g. `meta`, `br`) |
+| `h-attrs` | `element { k v … }` → `element` | Merges an attribute object onto an element |
+| `h-render` | `node` → `"html"` | Renders a node tree to an HTML string |
+
+### Dynamic `h-<tag>` shorthand
+
+Any name matching `h-<lowercase-tag>` that is not one of the static ops works as a shorthand: `block h-div` ≡ `block "div" h-tag` (registered via a dynamic registry pattern in `src/register.ts`).
+
+## Rendering rules
+
+- Text nodes and attribute values are HTML-escaped (`& < > " '`); `h-raw` output is not.
+- Boolean attributes: `true` renders as a bare attribute, `false` is omitted.
+- Void elements (`br`, `meta`, `img`, …) render without a closing tag.
+
+## JavaScript API
+
+```ts
+import { registerHTML, render, createElement, createText, createRaw, createFragment } from "jth-html";
+```
+
+Also exported: the operator implementations (`hTag`, `hText`, `hRaw`, `hFrag`, `hVoid`, `hAttrs`, `hRender`), node type interfaces (`ElementNode`, `TextNode`, `RawNode`, `FragmentNode`, `HtmlNode`), and `escapeHtml`.
+
+## Example
+
+See [`examples/html.jth`](../../examples/html.jth) in the repo root — it builds a full page and is covered by an end-to-end CLI test.

--- a/packages/jth-html/package.json
+++ b/packages/jth-html/package.json
@@ -35,5 +35,6 @@
   },
   "dependencies": {
     "jth-runtime": "^0.4.0"
-  }
+  },
+  "license": "MIT"
 }

--- a/packages/jth-html/package.json
+++ b/packages/jth-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jth-html",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -34,6 +34,6 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "jth-runtime": "0.3.0"
+    "jth-runtime": "^0.4.0"
   }
 }

--- a/packages/jth-html/package.json
+++ b/packages/jth-html/package.json
@@ -2,13 +2,36 @@
   "name": "jth-html",
   "version": "0.3.0",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./nodes": "./src/nodes.ts",
-    "./render": "./src/render.ts",
-    "./operators": "./src/operators.ts",
-    "./register": "./src/register.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./nodes": {
+      "types": "./dist/nodes.d.ts",
+      "default": "./dist/nodes.js"
+    },
+    "./render": {
+      "types": "./dist/render.d.ts",
+      "default": "./dist/render.js"
+    },
+    "./operators": {
+      "types": "./dist/operators.d.ts",
+      "default": "./dist/operators.js"
+    },
+    "./register": {
+      "types": "./dist/register.d.ts",
+      "default": "./dist/register.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "jth-runtime": "0.3.0"

--- a/packages/jth-html/tsconfig.build.json
+++ b/packages/jth-html/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declarationMap": false,
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/jth-html/tsup.config.ts
+++ b/packages/jth-html/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    "index": "src/index.ts",
+    "nodes": "src/nodes.ts",
+    "render": "src/render.ts",
+    "operators": "src/operators.ts",
+    "register": "src/register.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  target: "node20",
+  platform: "node",
+  tsconfig: "tsconfig.build.json",
+});

--- a/packages/jth-repl/package.json
+++ b/packages/jth-repl/package.json
@@ -26,5 +26,6 @@
     "jth-runtime": "^0.4.0",
     "jth-compiler": "^0.4.0",
     "jth-stdlib": "^0.4.0"
-  }
+  },
+  "license": "MIT"
 }

--- a/packages/jth-repl/package.json
+++ b/packages/jth-repl/package.json
@@ -2,10 +2,24 @@
   "name": "jth-repl",
   "version": "0.3.0",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./evaluator": "./src/evaluator.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./evaluator": {
+      "types": "./dist/evaluator.d.ts",
+      "default": "./dist/evaluator.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "jth-types": "0.3.0",

--- a/packages/jth-repl/package.json
+++ b/packages/jth-repl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jth-repl",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -22,9 +22,9 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "jth-types": "0.3.0",
-    "jth-runtime": "0.3.0",
-    "jth-compiler": "0.3.0",
-    "jth-stdlib": "0.3.0"
+    "jth-types": "^0.4.0",
+    "jth-runtime": "^0.4.0",
+    "jth-compiler": "^0.4.0",
+    "jth-stdlib": "^0.4.0"
   }
 }

--- a/packages/jth-repl/tsconfig.build.json
+++ b/packages/jth-repl/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declarationMap": false,
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/jth-repl/tsup.config.ts
+++ b/packages/jth-repl/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    "index": "src/index.ts",
+    "evaluator": "src/evaluator.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  target: "node20",
+  platform: "node",
+  tsconfig: "tsconfig.build.json",
+});

--- a/packages/jth-runtime/__tests__/process-n.test.ts
+++ b/packages/jth-runtime/__tests__/process-n.test.ts
@@ -359,3 +359,61 @@ describe("processN", () => {
     expect(s.toArray()).toEqual([1, 2, "a", "b"]);
   });
 });
+
+describe("processN async auto-promotion edge cases", () => {
+  const asyncDouble = op(1)(async (a) => {
+    await new Promise((r) => setTimeout(r, 5));
+    return [a * 2];
+  });
+  const syncInc = op(1)((a) => [a + 1]);
+
+  it("mixed sync and async ops execute in order with correct results", async () => {
+    const s = new Stack();
+    // sync -> async (promotes) -> sync (after promotion) -> async -> sync
+    const result = processN(s, [3, syncInc, asyncDouble, syncInc, asyncDouble, syncInc]);
+    expect(typeof (result as Promise<Stack>).then).toBe("function");
+    await result;
+    // ((3+1)*2 + 1) * 2 + 1 = 19
+    expect(s.toArray()).toEqual([19]);
+  });
+
+  it("values after the first async op are still processed in order", async () => {
+    const s = new Stack();
+    await processN(s, [1, asyncDouble, 10, 20, syncInc]);
+    expect(s.toArray()).toEqual([2, 10, 21]);
+  });
+
+  it("observable execution order is strictly sequential across the promotion", async () => {
+    const order: string[] = [];
+    const a = op(0)(() => { order.push("sync-1"); return []; });
+    const b = op(0)(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      order.push("async");
+      return [];
+    });
+    const c = op(0)(() => { order.push("sync-2"); return []; });
+    const s = new Stack();
+    await processN(s, [a, b, c]);
+    expect(order).toEqual(["sync-1", "async", "sync-2"]);
+  });
+
+  it("stays fully synchronous when no op returns a promise", () => {
+    const s = new Stack();
+    const result = processN(s, [1, syncInc, syncInc]);
+    expect(result).toBe(s); // no Promise on the sync fast path
+    expect(s.toArray()).toEqual([3]);
+  });
+
+  it("meta annotations still apply after async promotion (persist)", async () => {
+    const s = new Stack();
+    const asyncIncPersist = annotate(
+      op(1)(async (a) => {
+        await new Promise((r) => setTimeout(r, 1));
+        return [a + 1];
+      }),
+      { persist: 2 }
+    );
+    await processN(s, [0, asyncIncPersist]);
+    expect(s.toArray()).toEqual([3]); // ran 1 + 2 persisted times
+  });
+});

--- a/packages/jth-runtime/__tests__/registry.test.ts
+++ b/packages/jth-runtime/__tests__/registry.test.ts
@@ -92,3 +92,42 @@ describe("registry", () => {
     expect(fn()).toBe("first");
   });
 });
+
+describe("registry enumeration", () => {
+  beforeEach(() => {
+    registry.clear();
+  });
+
+  it("names() lists all static operator names", () => {
+    registry.set("alpha", () => {});
+    registry.set("beta", () => {});
+    expect(registry.names().sort()).toEqual(["alpha", "beta"]);
+  });
+
+  it("names() is empty after clear()", () => {
+    registry.set("x", () => {});
+    registry.clear();
+    expect(registry.names()).toEqual([]);
+  });
+
+  it("names() does not include dynamic pattern matches", () => {
+    registry.setDynamic(/^dyn-/, () => () => {});
+    expect(registry.names()).toEqual([]);
+    // ...even though the dynamic op resolves:
+    expect(registry.has("dyn-thing")).toBe(true);
+  });
+
+  it("dynamicPatterns() lists registered patterns", () => {
+    const p1 = /^dyn-/;
+    const p2 = /^\d+log$/;
+    registry.setDynamic(p1, () => () => {});
+    registry.setDynamic(p2, () => () => {});
+    expect(registry.dynamicPatterns()).toEqual([p1, p2]);
+  });
+
+  it("names() reflects remove()", () => {
+    registry.set("gone", () => {});
+    registry.remove("gone");
+    expect(registry.names()).toEqual([]);
+  });
+});

--- a/packages/jth-runtime/package.json
+++ b/packages/jth-runtime/package.json
@@ -2,14 +2,40 @@
   "name": "jth-runtime",
   "version": "0.3.0",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./stack": "./src/stack.ts",
-    "./op": "./src/op.ts",
-    "./meta": "./src/meta.ts",
-    "./process-n": "./src/process-n.ts",
-    "./registry": "./src/registry.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./stack": {
+      "types": "./dist/stack.d.ts",
+      "default": "./dist/stack.js"
+    },
+    "./op": {
+      "types": "./dist/op.d.ts",
+      "default": "./dist/op.js"
+    },
+    "./meta": {
+      "types": "./dist/meta.d.ts",
+      "default": "./dist/meta.js"
+    },
+    "./process-n": {
+      "types": "./dist/process-n.d.ts",
+      "default": "./dist/process-n.js"
+    },
+    "./registry": {
+      "types": "./dist/registry.d.ts",
+      "default": "./dist/registry.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "jth-types": "0.3.0"

--- a/packages/jth-runtime/package.json
+++ b/packages/jth-runtime/package.json
@@ -39,5 +39,6 @@
   },
   "dependencies": {
     "jth-types": "^0.4.0"
-  }
+  },
+  "license": "MIT"
 }

--- a/packages/jth-runtime/package.json
+++ b/packages/jth-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jth-runtime",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -38,6 +38,6 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "jth-types": "0.3.0"
+    "jth-types": "^0.4.0"
   }
 }

--- a/packages/jth-runtime/src/registry.ts
+++ b/packages/jth-runtime/src/registry.ts
@@ -73,6 +73,23 @@ export const registry = {
     return registry.get(name) !== undefined;
   },
 
+  /**
+   * Enumerate the names of all registered static operators.
+   * Dynamic pattern ops (setDynamic) match open-ended name families
+   * (e.g. "3+", "2log") and have no fixed names, so they are NOT
+   * included — use dynamicPatterns() to inspect those.
+   */
+  names(): string[] {
+    return [...staticOps.keys()];
+  },
+
+  /**
+   * The patterns of all registered dynamic operator factories.
+   */
+  dynamicPatterns(): RegExp[] {
+    return dynamicOps.map((d) => d.pattern);
+  },
+
   remove(name: string): boolean {
     return staticOps.delete(name);
   },

--- a/packages/jth-runtime/tsconfig.build.json
+++ b/packages/jth-runtime/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declarationMap": false,
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/jth-runtime/tsup.config.ts
+++ b/packages/jth-runtime/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    "index": "src/index.ts",
+    "stack": "src/stack.ts",
+    "op": "src/op.ts",
+    "meta": "src/meta.ts",
+    "process-n": "src/process-n.ts",
+    "registry": "src/registry.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  target: "node20",
+  platform: "node",
+  tsconfig: "tsconfig.build.json",
+});

--- a/packages/jth-stdlib/__tests__/async-ops.test.ts
+++ b/packages/jth-stdlib/__tests__/async-ops.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { Stack, op, processN } from "jth-runtime";
+import { wait, waitAll } from "../src/async-ops.ts";
+import { run } from "jth-compiler";
+import "../src/index.ts";
+
+describe("async-ops: wait (_)", () => {
+  it("awaits a promise on top of the stack", async () => {
+    const s = new Stack();
+    s.push(Promise.resolve(42));
+    await wait(s);
+    expect(s.toArray()).toEqual([42]);
+  });
+
+  it("passes non-promise values through unchanged", () => {
+    const s = new Stack();
+    s.push(7);
+    const result = wait(s);
+    expect(result).toBeUndefined(); // stays synchronous
+    expect(s.toArray()).toEqual([7]);
+  });
+
+  it("only awaits the top item", async () => {
+    const s = new Stack();
+    s.push(Promise.resolve("bottom"), Promise.resolve("top"));
+    await wait(s);
+    const arr = s.toArray();
+    expect(arr[1]).toBe("top");
+    expect(typeof (arr[0] as Promise<string>).then).toBe("function");
+  });
+
+  it("returns a thenable for promises (processN can promote)", () => {
+    const s = new Stack();
+    s.push(Promise.resolve(1));
+    const result = wait(s);
+    expect(typeof (result as Promise<void>).then).toBe("function");
+  });
+});
+
+describe("async-ops: waitAll (__)", () => {
+  it("awaits every promise on the stack, preserving order", async () => {
+    const s = new Stack();
+    s.push(Promise.resolve(1), 2, Promise.resolve(3));
+    await waitAll(s);
+    expect(s.toArray()).toEqual([1, 2, 3]);
+  });
+
+  it("works on an empty stack", async () => {
+    const s = new Stack();
+    await waitAll(s);
+    expect(s.toArray()).toEqual([]);
+  });
+
+  it("rejects if any promise rejects", async () => {
+    const s = new Stack();
+    s.push(Promise.resolve(1), Promise.reject(new Error("boom")));
+    await expect(waitAll(s)).rejects.toThrow("boom");
+  });
+});
+
+describe("async-ops: registered ops via processN / programs", () => {
+  it("_ resolves an async op result inside a program", async () => {
+    const s = new Stack();
+    const delayed = op(0)(async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      return [Promise.resolve(99)];
+    });
+    await processN(s, [delayed, wait]);
+    expect(s.toArray()).toEqual([99]);
+  });
+
+  it("__ resolves all promises via a jth program", async () => {
+    const { run: runJth } = await import("jth-compiler");
+    // no promises on the stack: __ is a no-op passthrough
+    const { stack } = await runJth("1 2 3 __;");
+    expect(stack.toArray()).toEqual([1, 2, 3]);
+  });
+
+  it("_ passes plain values through in a jth program", async () => {
+    const { stack } = await run("5 _;");
+    expect(stack.toArray()).toEqual([5]);
+  });
+});

--- a/packages/jth-stdlib/__tests__/dynamic-ops.test.ts
+++ b/packages/jth-stdlib/__tests__/dynamic-ops.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { Stack, registry } from "jth-runtime";
+import { run } from "jth-compiler";
+import "../src/index.ts";
+
+/** Resolve a dynamic op and apply it to a stack seeded with `top`. */
+function applyDynamic(name: string, top: unknown): unknown[] {
+  const fn = registry.get(name);
+  expect(fn, `expected dynamic op "${name}" to resolve`).toBeDefined();
+  const s = new Stack();
+  s.push(top);
+  fn!(s);
+  return s.toArray();
+}
+
+describe("dynamic-ops: N<op> arithmetic patterns", () => {
+  it('"3+" adds the literal', () => {
+    expect(applyDynamic("3+", 4)).toEqual([7]);
+  });
+
+  it('"10-" subtracts the top FROM the literal (n - a)', () => {
+    expect(applyDynamic("10-", 4)).toEqual([6]);
+  });
+
+  it('"14*" multiplies', () => {
+    expect(applyDynamic("14*", 2)).toEqual([28]);
+  });
+
+  it('"⋅" alias multiplies ("3⋅")', () => {
+    expect(applyDynamic("3⋅", 5)).toEqual([15]);
+  });
+
+  it('"20/" divides the literal by the top (n / a)', () => {
+    expect(applyDynamic("20/", 5)).toEqual([4]);
+  });
+
+  it('"÷" alias divides ("20÷")', () => {
+    expect(applyDynamic("20÷", 4)).toEqual([5]);
+  });
+
+  it('"2**" raises the literal to the top (n ** a)', () => {
+    expect(applyDynamic("2**", 10)).toEqual([1024]);
+  });
+
+  it('"7%" is a floored modulo of the literal by the top', () => {
+    expect(applyDynamic("7%", 3)).toEqual([1]);
+  });
+
+  it('"%" flooring differs from "%%" remainder for negative operands', () => {
+    expect(applyDynamic("-7%", 3)).toEqual([2]); // ((-7 % 3) + 3) % 3
+    expect(applyDynamic("-7%%", 3)).toEqual([-1]); // plain remainder
+  });
+
+  it("supports decimal literals ('0.5+')", () => {
+    expect(applyDynamic("0.5+", 1)).toEqual([1.5]);
+  });
+
+  it("supports negative literals ('-3+')", () => {
+    expect(applyDynamic("-3+", 10)).toEqual([7]);
+  });
+});
+
+describe("dynamic-ops: BigInt-aware paths (Nn<op>)", () => {
+  it('"3n+" adds BigInts', () => {
+    expect(applyDynamic("3n+", 4n)).toEqual([7n]);
+  });
+
+  it('"2n**" exponentiates BigInts', () => {
+    expect(applyDynamic("2n**", 64n)).toEqual([18446744073709551616n]);
+  });
+
+  it('"10n-" subtracts BigInts', () => {
+    expect(applyDynamic("10n-", 4n)).toEqual([6n]);
+  });
+});
+
+describe("dynamic-ops: Nlog patterns", () => {
+  it('"2log" computes log base 2', () => {
+    const [result] = applyDynamic("2log", 8);
+    expect(result).toBeCloseTo(3);
+  });
+
+  it('"10log" computes log base 10', () => {
+    const [result] = applyDynamic("10log", 1000);
+    expect(result).toBeCloseTo(3);
+  });
+});
+
+describe("dynamic-ops: via jth programs", () => {
+  it("4 3+ evaluates to 7", async () => {
+    const { value } = await run("4 3+;");
+    expect(value).toBe(7);
+  });
+
+  it("8 2log evaluates to 3", async () => {
+    const { value } = await run("8 2log;");
+    expect(value).toBeCloseTo(3);
+  });
+});
+
+describe("dynamic-ops: non-matching names do not resolve", () => {
+  it("plain words are not captured by the numeric patterns", () => {
+    expect(registry.get("nosuchop")).toBeUndefined();
+  });
+});

--- a/packages/jth-stdlib/__tests__/hyperoperations.test.ts
+++ b/packages/jth-stdlib/__tests__/hyperoperations.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { Stack, registry } from "jth-runtime";
+import { hyperoperation } from "../src/hyperoperations.ts";
+import { run } from "jth-compiler";
+import "../src/index.ts";
+
+describe("hyperoperation(n) semantics", () => {
+  it("n=0 is successor of a (b unused)", () => {
+    expect(hyperoperation(0)(5, 0)).toBe(6);
+    // The b parameter defaults to 0n, so the one-arg form needs BigInt a:
+    expect(hyperoperation(0n)(5n)).toBe(6n);
+  });
+
+  it("n=1 is addition", () => {
+    expect(hyperoperation(1)(2, 3)).toBe(5);
+  });
+
+  it("n=2 is multiplication", () => {
+    expect(hyperoperation(2)(4, 5)).toBe(20);
+  });
+
+  it("n=3 is exponentiation", () => {
+    expect(hyperoperation(3)(2, 10)).toBe(1024);
+  });
+
+  it("n=4 is tetration", () => {
+    expect(hyperoperation(4)(2, 3)).toBe(16); // 2^(2^2)
+    expect(hyperoperation(4)(3, 2)).toBe(27); // 3^3
+  });
+
+  it("n=5 is pentation", () => {
+    expect(hyperoperation(5)(2, 2)).toBe(4);
+    expect(hyperoperation(5)(2, 3)).toBe(65536);
+  });
+
+  it("base cases: b=0 -> 1, b=1 -> a, a=1 -> 1 (n>3)", () => {
+    expect(hyperoperation(4)(7, 0)).toBe(1);
+    expect(hyperoperation(4)(7, 1)).toBe(7);
+    expect(hyperoperation(5)(1, 99)).toBe(1);
+  });
+
+  it("works with BigInt inputs (returns BigInt)", () => {
+    expect(hyperoperation(4n)(2n, 3n)).toBe(16n);
+    expect(hyperoperation(3n)(2n, 64n)).toBe(18446744073709551616n);
+  });
+});
+
+describe("hyperoperation error throws", () => {
+  it("throws HYPEROP_DOMAIN for non-integer arguments", () => {
+    expect(() => hyperoperation(4)(1.5, 2)).toThrow(
+      "All arguments must be integers or BigInts"
+    );
+    try {
+      hyperoperation(4)(1.5, 2);
+      expect.unreachable();
+    } catch (e: any) {
+      expect(e.code).toBe("HYPEROP_DOMAIN");
+    }
+  });
+
+  it("throws HYPEROP_DOMAIN for negative BigInt arguments", () => {
+    expect(() => hyperoperation(4n)(-1n, 2n)).toThrow(
+      "Non-negative integers only"
+    );
+    try {
+      hyperoperation(4n)(-1n, 2n);
+      expect.unreachable();
+    } catch (e: any) {
+      expect(e.code).toBe("HYPEROP_DOMAIN");
+    }
+  });
+
+  it("Number path maps overflow/domain errors to Infinity", () => {
+    // The Number branch catches the internal throw and yields Infinity.
+    expect(hyperoperation(4)(-1, 2)).toBe(Infinity);
+  });
+
+  it("throws for a mix of Number and non-integer", () => {
+    expect(() => hyperoperation(2)(2, "x")).toThrow(
+      "All arguments must be integers or BigInts"
+    );
+  });
+});
+
+describe("hyperoperations: dynamic *** registration", () => {
+  it('"***" resolves to tetration (n=4)', () => {
+    const fn = registry.get("***");
+    expect(fn).toBeDefined();
+    const s = new Stack();
+    s.push(2, 3);
+    fn!(s);
+    expect(s.toArray()).toEqual([16]);
+  });
+
+  it('"****" resolves to pentation (n=5)', () => {
+    const fn = registry.get("****");
+    expect(fn).toBeDefined();
+    const s = new Stack();
+    s.push(2, 2);
+    fn!(s);
+    expect(s.toArray()).toEqual([4]);
+  });
+
+  it('"**" is NOT captured by the dynamic pattern (static exp op)', () => {
+    // The pattern requires 3+ asterisks; ** is plain exponentiation.
+    const s = new Stack();
+    s.push(2, 8);
+    registry.resolve("**")(s);
+    expect(s.toArray()).toEqual([256]);
+  });
+
+  it("works via a jth program", async () => {
+    const { value } = await run("2 3 ***;");
+    expect(value).toBe(16);
+  });
+});

--- a/packages/jth-stdlib/__tests__/iterator-ops.test.ts
+++ b/packages/jth-stdlib/__tests__/iterator-ops.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { Stack, registry } from "jth-runtime";
+import { next, drain, iter, exhaustIterator } from "../src/iterator-ops.ts";
+import { run } from "jth-compiler";
+import "../src/index.ts";
+
+describe("iterator-ops: iter", () => {
+  it("converts an iterable to an iterator", () => {
+    const s = new Stack();
+    s.push([1, 2, 3]);
+    iter(s);
+    const it = s.peek() as Iterator<number>;
+    expect(typeof it.next).toBe("function");
+    expect(it.next()).toEqual({ done: false, value: 1 });
+  });
+
+  it("works with strings", () => {
+    const s = new Stack();
+    s.push("ab");
+    iter(s);
+    const it = s.peek() as Iterator<string>;
+    expect(it.next()).toEqual({ done: false, value: "a" });
+  });
+
+  it("passes non-iterables through unchanged", () => {
+    const s = new Stack();
+    s.push(42);
+    iter(s);
+    expect(s.toArray()).toEqual([42]);
+  });
+});
+
+describe("iterator-ops: next", () => {
+  it("pulls the next value, keeping the iterator below it", () => {
+    const s = new Stack();
+    s.push([10, 20][Symbol.iterator]());
+    next(s);
+    const arr = s.toArray();
+    expect(arr).toHaveLength(2);
+    expect(typeof (arr[0] as Iterator<number>).next).toBe("function");
+    expect(arr[1]).toBe(10);
+  });
+
+  it("on exhaustion pushes only the iterator back", () => {
+    const s = new Stack();
+    const it = [][Symbol.iterator]();
+    s.push(it);
+    next(s);
+    expect(s.toArray()).toEqual([it]);
+  });
+
+  it("passes non-iterators through unchanged", () => {
+    const s = new Stack();
+    s.push("plain");
+    next(s);
+    expect(s.toArray()).toEqual(["plain"]);
+  });
+
+  it("successive next calls walk the iterator", () => {
+    const s = new Stack();
+    s.push([1, 2][Symbol.iterator]());
+    next(s);
+    const value1 = s.pop();
+    next(s);
+    const value2 = s.pop();
+    expect([value1, value2]).toEqual([1, 2]);
+  });
+});
+
+describe("iterator-ops: drain", () => {
+  it("drains n values, iterator stays on top", () => {
+    const s = new Stack();
+    s.push([1, 2, 3, 4][Symbol.iterator]());
+    drain(3)(s);
+    const arr = s.toArray();
+    expect(arr.slice(0, 3)).toEqual([1, 2, 3]);
+    expect(typeof (arr[3] as Iterator<number>).next).toBe("function");
+  });
+
+  it("stops early when the iterator is exhausted", () => {
+    const s = new Stack();
+    s.push([1][Symbol.iterator]());
+    drain(5)(s);
+    const arr = s.toArray();
+    expect(arr).toHaveLength(2);
+    expect(arr[0]).toBe(1);
+  });
+
+  it("defaults to draining one value", () => {
+    const s = new Stack();
+    s.push([7, 8][Symbol.iterator]());
+    drain()(s);
+    const arr = s.toArray();
+    expect(arr[0]).toBe(7);
+    expect(arr).toHaveLength(2);
+  });
+
+  it("passes non-iterators through unchanged", () => {
+    const s = new Stack();
+    s.push(99);
+    drain(2)(s);
+    expect(s.toArray()).toEqual([99]);
+  });
+});
+
+describe("iterator-ops: exhaustIterator (..)", () => {
+  it("collects all remaining values into an array", () => {
+    const s = new Stack();
+    s.push([1, 2, 3][Symbol.iterator]());
+    exhaustIterator(s);
+    expect(s.toArray()).toEqual([[1, 2, 3]]);
+  });
+
+  it("spreads any iterable (e.g. a string)", () => {
+    const s = new Stack();
+    s.push("abc");
+    exhaustIterator(s);
+    expect(s.toArray()).toEqual([["a", "b", "c"]]);
+  });
+
+  it("passes non-iterables through unchanged", () => {
+    const s = new Stack();
+    s.push(5);
+    exhaustIterator(s);
+    expect(s.toArray()).toEqual([5]);
+  });
+});
+
+describe("iterator-ops: registered ops via jth programs", () => {
+  it("iter + next pull values from an array", async () => {
+    const { stack } = await run("[10 20 30] iter next;");
+    const arr = stack.toArray();
+    expect(arr[arr.length - 1]).toBe(10);
+  });
+
+  it('".." is registered (the lexer does not currently tokenize it, so via registry)', () => {
+    // Note: `..` in jth source lexes as two `.` operators, so the ".."
+    // registration is only reachable programmatically today.
+    const fn = registry.get("..");
+    expect(fn).toBe(exhaustIterator);
+    const s = new Stack();
+    s.push([4, 5][Symbol.iterator]());
+    fn!(s);
+    expect(s.toArray()).toEqual([[4, 5]]);
+  });
+});

--- a/packages/jth-stdlib/__tests__/meta-ops.test.ts
+++ b/packages/jth-stdlib/__tests__/meta-ops.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { Stack, processN } from "jth-runtime";
+import { execute, executeSpread } from "../src/meta-ops.ts";
+import { run } from "jth-compiler";
+import "../src/index.ts";
+
+describe("meta-ops: execute ($)", () => {
+  it("pops and executes a function with the stack", () => {
+    const s = new Stack();
+    s.push(1, 2);
+    s.push((stack: Stack) => {
+      const b = stack.pop() as number;
+      const a = stack.pop() as number;
+      stack.push(a + b);
+    });
+    execute(s);
+    expect(s.toArray()).toEqual([3]);
+  });
+
+  it("returns the promise of an async block so callers can await", async () => {
+    const s = new Stack();
+    s.push(async (stack: Stack) => {
+      await new Promise((r) => setTimeout(r, 5));
+      stack.push("done");
+    });
+    const result = execute(s);
+    expect(typeof (result as Promise<void>).then).toBe("function");
+    await result;
+    expect(s.toArray()).toEqual(["done"]);
+  });
+
+  it("silently drops a non-function top value", () => {
+    const s = new Stack();
+    s.push(1, 42);
+    execute(s);
+    expect(s.toArray()).toEqual([1]);
+  });
+});
+
+describe("meta-ops: executeSpread ($$)", () => {
+  it("pops an array and processes its items against the stack", async () => {
+    const s = new Stack();
+    s.push([1, 2, (stack: Stack) => {
+      const b = stack.pop() as number;
+      const a = stack.pop() as number;
+      stack.push(a * b);
+    }]);
+    await executeSpread(s);
+    expect(s.toArray()).toEqual([2]);
+  });
+
+  it("does nothing when top is not an array", () => {
+    const s = new Stack();
+    s.push(1, "not-array");
+    executeSpread(s);
+    expect(s.toArray()).toEqual([1]);
+  });
+});
+
+describe("meta-ops: registered ops via jth programs", () => {
+  it("$ executes a block from the stack", async () => {
+    const { value } = await run("1 2 #[ + ] $;");
+    expect(value).toBe(3);
+  });
+
+  it("$$ executes an array as a program", async () => {
+    const s = new Stack();
+    // build [3 4 +] as data, then execute it
+    const { registry } = await import("jth-runtime");
+    s.push([3, 4, registry.resolve("+")]);
+    await processN(s, [registry.resolve("$$")]);
+    expect(s.toArray()).toEqual([7]);
+  });
+
+  it("->> (skip -1) pushes the rest of the statement as values", async () => {
+    // Without ->>, `+` would execute; after ->>, it lands on the stack
+    // as a bare function value instead.
+    const { stack } = await run("1 2 ->> +;");
+    const arr = stack.toArray();
+    expect(arr.slice(0, 2)).toEqual([1, 2]);
+    expect(typeof arr[2]).toBe("function");
+    expect(arr).toHaveLength(3);
+  });
+
+  it("<<- (rewind -1) re-queues stack items for processing", async () => {
+    // The block lands on the stack as a value; <<- rewinds the whole
+    // stack back into the queue, so the block is executed this time.
+    const { value, stack } = await run("1 2 #[ + ] <<-;");
+    expect(stack.toArray()).toEqual([3]);
+    expect(value).toBe(3);
+  });
+});

--- a/packages/jth-stdlib/__tests__/sequences.test.ts
+++ b/packages/jth-stdlib/__tests__/sequences.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { Stack } from "jth-runtime";
+import { fibonacci } from "../src/sequences.ts";
+import { run } from "jth-compiler";
+import "../src/index.ts";
+
+describe("sequences: fibonacci", () => {
+  it("(a b -- b a a+b): pushes three values", () => {
+    const s = new Stack();
+    s.push(2, 3);
+    fibonacci(s);
+    expect(s.toArray()).toEqual([3, 2, 5]);
+  });
+
+  it("starts the sequence from (0, 1)", () => {
+    const s = new Stack();
+    s.push(0, 1);
+    fibonacci(s);
+    expect(s.toArray()).toEqual([1, 0, 1]);
+  });
+
+  it("iterates with the `swap drop` trim idiom (as in examples/fibonacci.jth)", () => {
+    const s = new Stack();
+    s.push(0, 1);
+    for (let i = 0; i < 5; i++) {
+      fibonacci(s); // [b, a, a+b]
+      s.swap(); // [b, a+b, a]
+      s.pop(); // [b, a+b]
+    }
+    expect(s.toArray()).toEqual([5, 8]);
+  });
+
+  it("is registered and usable from a jth program", async () => {
+    const { value } = await run("0 1 #[ fibonacci swap drop ] 6 times;");
+    expect(value).toBe(13); // 0 1 1 2 3 5 8 13
+  });
+});

--- a/packages/jth-stdlib/package.json
+++ b/packages/jth-stdlib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jth-stdlib",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "jth-types": "0.3.0",
-    "jth-runtime": "0.3.0"
+    "jth-types": "^0.4.0",
+    "jth-runtime": "^0.4.0"
   }
 }

--- a/packages/jth-stdlib/package.json
+++ b/packages/jth-stdlib/package.json
@@ -2,9 +2,20 @@
   "name": "jth-stdlib",
   "version": "0.3.0",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "jth-types": "0.3.0",

--- a/packages/jth-stdlib/package.json
+++ b/packages/jth-stdlib/package.json
@@ -20,5 +20,6 @@
   "dependencies": {
     "jth-types": "^0.4.0",
     "jth-runtime": "^0.4.0"
-  }
+  },
+  "license": "MIT"
 }

--- a/packages/jth-stdlib/tsconfig.build.json
+++ b/packages/jth-stdlib/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declarationMap": false,
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/jth-stdlib/tsup.config.ts
+++ b/packages/jth-stdlib/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    "index": "src/index.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  target: "node20",
+  platform: "node",
+  tsconfig: "tsconfig.build.json",
+});

--- a/packages/jth-types/README.md
+++ b/packages/jth-types/README.md
@@ -1,0 +1,55 @@
+# jth-types
+
+Shared type contract for the jth language: token definitions, AST node interfaces and constructors, meta-annotation interfaces, and the error hierarchy. This package is the single source of truth imported by `jth-compiler` (lexer/parser/codegen) and `jth-runtime` — it has no dependencies of its own.
+
+## Installation
+
+```bash
+npm install jth-types
+```
+
+## Public exports
+
+| Subpath | Contents |
+|---------|----------|
+| `jth-types` (root) | Re-exports everything below |
+| `jth-types/tokens` | `TokenType` (frozen enum of lexer token kinds), `token()` constructor, `Token` / `TokenTypeValue` types |
+| `jth-types/ast` | AST node constructors and their TypeScript interfaces (see below) |
+| `jth-types/errors` | `JthError` hierarchy |
+| `jth-types/interfaces` | `MetaAnnotations` (delay/persist/rewind/skip/limit), `UNLIMITED` sentinel |
+
+### AST nodes
+
+Constructors (each returns a plain object with a `type` field plus `line`/`column`):
+`ProgramNode`, `NumberLiteral`, `StringLiteral`, `BooleanLiteral`, `NullLiteral`, `UndefinedLiteral`, `OperatorCallNode`, `ArrayLiteral`, `BlockLiteral`, `JSObjectLiteral`, `InlineJSExpression`, `DefinitionNode`, `ValueDefinitionNode`, `ImportNode`, `ExportNode`, `StatementNode`.
+
+Matching interfaces are exported with a `Type` suffix (e.g. `NumberLiteralType`, `ProgramNodeType`), plus the `ASTNode` union and `JSObjectProperty`.
+
+### Errors
+
+All errors carry a source position (`line` / `column`, `null` when unknown):
+
+```
+JthError
+├── JthLexerError
+├── JthParserError
+└── JthRuntimeError   (adds machine-readable `code`, e.g. "UNKNOWN_OPERATOR",
+                       "ITERATION_LIMIT", "OP_NOT_ALLOWED")
+```
+
+## Example
+
+```ts
+import { JthRuntimeError, TokenType } from "jth-types";
+import { NumberLiteral } from "jth-types/ast";
+
+const node = NumberLiteral(42, 1, 0);
+// { type: "NumberLiteral", value: 42, line: 1, column: 0 }
+
+throw new JthRuntimeError("Unknown operator: foo", 3, 7, "UNKNOWN_OPERATOR");
+```
+
+## Notes
+
+- The package is types + tiny constructors only; there is no runtime logic here.
+- Some AST constructors are consumed only by the parser (`jth-compiler`); all are exported so external tooling can build jth ASTs programmatically.

--- a/packages/jth-types/package.json
+++ b/packages/jth-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jth-types",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/jth-types/package.json
+++ b/packages/jth-types/package.json
@@ -32,5 +32,6 @@
   "scripts": {
     "build": "tsup",
     "prepublishOnly": "npm run build"
-  }
+  },
+  "license": "MIT"
 }

--- a/packages/jth-types/package.json
+++ b/packages/jth-types/package.json
@@ -2,12 +2,35 @@
   "name": "jth-types",
   "version": "0.3.0",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./tokens": "./src/tokens.ts",
-    "./ast": "./src/ast.ts",
-    "./errors": "./src/errors.ts",
-    "./interfaces": "./src/interfaces.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./tokens": {
+      "types": "./dist/tokens.d.ts",
+      "default": "./dist/tokens.js"
+    },
+    "./ast": {
+      "types": "./dist/ast.d.ts",
+      "default": "./dist/ast.js"
+    },
+    "./errors": {
+      "types": "./dist/errors.d.ts",
+      "default": "./dist/errors.js"
+    },
+    "./interfaces": {
+      "types": "./dist/interfaces.d.ts",
+      "default": "./dist/interfaces.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "prepublishOnly": "npm run build"
   }
 }

--- a/packages/jth-types/tsconfig.build.json
+++ b/packages/jth-types/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declarationMap": false,
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/jth-types/tsup.config.ts
+++ b/packages/jth-types/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    "index": "src/index.ts",
+    "tokens": "src/tokens.ts",
+    "ast": "src/ast.ts",
+    "errors": "src/errors.ts",
+    "interfaces": "src/interfaces.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  target: "node20",
+  platform: "node",
+  tsconfig: "tsconfig.build.json",
+});

--- a/test/e2e/examples.test.ts
+++ b/test/e2e/examples.test.ts
@@ -1,0 +1,54 @@
+/**
+ * End-to-end tests that run shipped example programs through the REAL CLI
+ * (spawned process), proving the opt-in op-package load path works:
+ * examples/html.jth declares `::import "jth-html";`, which the compiler
+ * passes through so jth-html side-effect-registers its `h-*` ops.
+ */
+
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..", "..");
+
+/** Run the jth CLI with the given args, from the repo root. */
+function jth(...args: string[]) {
+  const bin = resolve(repoRoot, "packages", "jth-cli", "bin", "jth.ts");
+  return spawnSync(process.execPath, ["--import", "tsx", bin, ...args], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    timeout: 60_000,
+  });
+}
+
+describe("E2E: jth run examples/html.jth (opt-in jth-html import)", () => {
+  it("renders the expected HTML with no manual setup", () => {
+    const result = jth("run", "examples/html.jth");
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(
+      "<html>" +
+        "<head>" +
+        '<meta charset="utf-8">' +
+        "<title>My Page</title>" +
+        "</head>" +
+        "<body>" +
+        "<h1>Hello, World!</h1>" +
+        "<main>" +
+        "<p>Welcome to jth-html.</p>" +
+        "<ul><li>Item 1</li><li>Item 2</li></ul>" +
+        "</main>" +
+        "</body>" +
+        "</html>"
+    );
+  });
+});
+
+describe("E2E: jth run examples/hello.jth", () => {
+  it("prints the greeting", () => {
+    const result = jth("run", "examples/hello.jth");
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("Hello, World!");
+  });
+});

--- a/test/e2e/examples.test.ts
+++ b/test/e2e/examples.test.ts
@@ -13,10 +13,10 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "..", "..");
 
-/** Run the jth CLI with the given args, from the repo root. */
+/** Run the built jth CLI with the given args, from the repo root. */
 function jth(...args: string[]) {
-  const bin = resolve(repoRoot, "packages", "jth-cli", "bin", "jth.ts");
-  return spawnSync(process.execPath, ["--import", "tsx", bin, ...args], {
+  const bin = resolve(repoRoot, "packages", "jth-cli", "dist", "bin", "jth.js");
+  return spawnSync(process.execPath, [bin, ...args], {
     cwd: repoRoot,
     encoding: "utf-8",
     timeout: 60_000,

--- a/test/smoke/pack-install.test.ts
+++ b/test/smoke/pack-install.test.ts
@@ -1,0 +1,101 @@
+/**
+ * SLOW smoke test: prove jth-lang is actually installable and usable
+ * outside the monorepo.
+ *
+ * Flow: `npm pack` jth-lang and its workspace dependencies into a temp
+ * dir OUTSIDE the repo, `npm install` the tarballs there (the tarball
+ * versions satisfy each other's version ranges, so nothing jth-* is
+ * fetched from the registry), then run the installed `jth` binary on a
+ * hello program with plain node.
+ *
+ * Requires a build (root `npm test` builds first) and network access for
+ * jth-lang's third-party dependency (esbuild).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, readdirSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..");
+
+// jth-lang plus every jth-* package in its dependency closure.
+const PACKAGES = [
+  "jth-types",
+  "jth-runtime",
+  "jth-compiler",
+  "jth-stdlib",
+  "jth-repl",
+  "jth-cli", // directory name; the package inside is "jth-lang"
+];
+
+const INSTALL_TIMEOUT = 300_000;
+
+function sh(cmd: string, args: string[], cwd: string) {
+  return spawnSync(cmd, args, { cwd, encoding: "utf-8", timeout: INSTALL_TIMEOUT });
+}
+
+describe("smoke: npm pack + install + run outside the repo", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "jth-smoke-"));
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it(
+    "packs, installs, and runs `jth run hello.jth` from a clean directory",
+    () => {
+      // 1. Pack each workspace package into the temp dir.
+      for (const pkg of PACKAGES) {
+        const result = sh("npm", ["pack", "--pack-destination", dir], join(REPO_ROOT, "packages", pkg));
+        expect(result.status, `npm pack failed for ${pkg}: ${result.stderr}`).toBe(0);
+      }
+      const tarballs = readdirSync(dir).filter((f) => f.endsWith(".tgz"));
+      expect(tarballs.length).toBe(PACKAGES.length);
+
+      // 2. Install the tarballs into a fresh project.
+      const init = sh("npm", ["init", "-y"], dir);
+      expect(init.status).toBe(0);
+      const install = sh(
+        "npm",
+        ["install", "--no-audit", "--no-fund", ...tarballs.map((t) => `./${t}`)],
+        dir
+      );
+      expect(install.status, `npm install failed: ${install.stderr}`).toBe(0);
+
+      // 3. Run a hello program via the installed binary (plain node stack;
+      //    tsx is not installed here).
+      writeFileSync(join(dir, "hello.jth"), '"Hello from installed jth!" peek;', "utf-8");
+      const jthBin = join(dir, "node_modules", ".bin", "jth");
+      const run = sh(jthBin, ["run", "hello.jth"], dir);
+      expect(run.status, `jth run failed: ${run.stderr}`).toBe(0);
+      expect(run.stdout.trim()).toBe("Hello from installed jth!");
+
+      // 4. `jth compile` from the installed CLI produces a self-contained
+      //    bundle runnable with plain node from yet another directory.
+      const compile = sh(jthBin, ["compile", "hello.jth", "out.mjs"], dir);
+      expect(compile.status, `jth compile failed: ${compile.stderr}`).toBe(0);
+      const elsewhere = mkdtempSync(join(tmpdir(), "jth-smoke-elsewhere-"));
+      try {
+        const node = sh(process.execPath, [join(dir, "out.mjs")], elsewhere);
+        expect(node.status).toBe(0);
+        expect(node.stdout.trim()).toBe("Hello from installed jth!");
+      } finally {
+        rmSync(elsewhere, { recursive: true, force: true });
+      }
+
+      // 5. Version sanity: the installed binary reports the package version.
+      const version = sh(jthBin, ["--version"], dir);
+      expect(version.status).toBe(0);
+      expect(version.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+    },
+    INSTALL_TIMEOUT
+  );
+});


### PR DESCRIPTION
Completes the remaining planner-issues and makes jth publishable to npm:

- #20 READMEs for jth-types/jth-html/jth-eval; jth-eval converted to TypeScript and added to the project graph
- #21 op-package loading e2e-tested (`::import "jth-html"` works out of the box); jth-ai documented as JS-only helper
- #22 real sandbox restriction: registry enumeration, default-deny, inline JS blocked at compile time (`OP_NOT_ALLOWED`)
- #25 coverage gaps closed: 6 untested stdlib modules + `jth run` spawn path + async-promotion edge cases
- #17 publishability: **jth-cli → jth-lang** (binary stays `jth`), tsup dist builds for all 9 packages, plain-node bin (no runtime tsx), self-contained esbuild bundles from `jth compile`, pack-and-install smoke test that runs outside the repo tree
- Version bump: everything 0.3.0 → **0.4.0**
- Release-triggered npm publish workflow + PUBLISHING.md
- MIT license (repo + all package.json files)

Suite: **1082 tests passing** across 49 files; `tsc -b` and `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)